### PR TITLE
Expire open-ended events after two hours

### DIFF
--- a/LSE Now/Models/Post.swift
+++ b/LSE Now/Models/Post.swift
@@ -23,4 +23,35 @@ struct Post: Identifiable, Codable, Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
+
+    func isExpired(referenceDate: Date = Date()) -> Bool {
+        guard endTime == nil else { return false }
+        let expiryCutoff = startTime.addingTimeInterval(2 * 3600)
+        return referenceDate >= expiryCutoff
+    }
+
+    func updatingStatusForExpiry(referenceDate: Date = Date()) -> Post {
+        guard isExpired(referenceDate: referenceDate) else { return self }
+        if status?.lowercased() == "expired" { return self }
+        return Post(
+            id: id,
+            title: title,
+            startTime: startTime,
+            endTime: endTime,
+            location: location,
+            description: description,
+            organization: organization,
+            category: category,
+            imageUrl: imageUrl,
+            status: "expired",
+            latitude: latitude,
+            longitude: longitude,
+            contact: contact
+        )
+    }
+
+    var resolvedStatus: String {
+        if isExpired() { return "expired" }
+        return status ?? "pending"
+    }
 }

--- a/LSE Now/ViewModels/PostListViewModel.swift
+++ b/LSE Now/ViewModels/PostListViewModel.swift
@@ -4,6 +4,14 @@ class PostListViewModel: ObservableObject {
     @Published var posts: [Post] = []
     @Published var isLoading: Bool = false
 
+    private var allPosts: [Post] = []
+    private var expiryTimer: Timer?
+    private let expiryCheckInterval: TimeInterval = 60
+
+    deinit {
+        expiryTimer?.invalidate()
+    }
+
     func fetchPosts() {
         isLoading = true
         guard let url = URL(string: "https://www.canovari.com/api/events.php") else { return }
@@ -29,10 +37,14 @@ class PostListViewModel: ObservableObject {
             }
 
             do {
-                let result = try decoder.decode([Post].self, from: data)
+                let decodedPosts = try decoder.decode([Post].self, from: data)
+
                 DispatchQueue.main.async {
-                    print("✅ Decoded posts count:", result.count)
-                    self.posts = result
+                    print("✅ Decoded posts count:", decodedPosts.count)
+                    self.allPosts = decodedPosts
+                    self.applyExpiryPolicy()
+                    print("📦 Active posts after expiry filter:", self.posts.count)
+                    self.startExpiryTimer()
                 }
             } catch {
                 print("❌ Decoding error:", error)
@@ -40,4 +52,46 @@ class PostListViewModel: ObservableObject {
         }.resume()
     }
 
+    private func applyExpiryPolicy(referenceDate: Date = Date()) {
+        guard !allPosts.isEmpty else {
+            if !posts.isEmpty {
+                posts = []
+            }
+            stopExpiryTimer()
+            return
+        }
+
+        let processedPosts = allPosts.map { $0.updatingStatusForExpiry(referenceDate: referenceDate) }
+        allPosts = processedPosts
+
+        let previousCount = posts.count
+        let activePosts = processedPosts.filter { !$0.isExpired(referenceDate: referenceDate) }
+        posts = activePosts
+
+        let removedCount = max(0, previousCount - activePosts.count)
+        if removedCount > 0 {
+            print("🕒 Expired posts removed:", removedCount)
+        }
+
+        if activePosts.isEmpty {
+            stopExpiryTimer()
+        }
+    }
+
+    private func startExpiryTimer() {
+        stopExpiryTimer()
+        guard !posts.isEmpty else { return }
+
+        expiryTimer = Timer.scheduledTimer(withTimeInterval: expiryCheckInterval, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.applyExpiryPolicy()
+            }
+        }
+    }
+
+    private func stopExpiryTimer() {
+        expiryTimer?.invalidate()
+        expiryTimer = nil
+    }
 }


### PR DESCRIPTION
## Summary
- add helpers on `Post` to determine expiry and expose an "expired" status
- process fetched events in `PostListViewModel` so open-ended events fall out of the feed once they have been running for two hours
- schedule a repeating expiry check to keep the feed/map trimmed without requiring another fetch

## Testing
- not run (iOS project without automated tests in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbf84ffc5c83229e7f01232805dd02