### PR TITLE
Handle Instagram usernames for event contacts

### DIFF
--- a/LSE Now/Models/ContactInfo.swift
+++ b/LSE Now/Models/ContactInfo.swift
@@ -3,4 +3,72 @@ import Foundation
 struct ContactInfo: Codable, Hashable {
     var type: String
     var value: String
+
+    var displayValue: String {
+        ContactInfo.displayValue(for: type, storedValue: value)
+    }
+
+    static func sanitizedValue(for type: String, rawValue: String) -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch type.lowercased() {
+        case "instagram":
+            return instagramHandle(from: trimmed)
+        default:
+            return trimmed
+        }
+    }
+
+    static func displayValue(for type: String, storedValue: String) -> String {
+        let trimmed = storedValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch type.lowercased() {
+        case "instagram":
+            guard !trimmed.isEmpty else { return "" }
+            let handle = instagramHandle(from: trimmed)
+            if handle.isEmpty { return trimmed }
+            return "@\(handle)"
+        default:
+            return trimmed
+        }
+    }
+
+    static func instagramHandle(from rawValue: String) -> String {
+        var handle = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !handle.isEmpty else { return "" }
+
+        if let schemeRange = handle.range(of: "://") {
+            handle = String(handle[schemeRange.upperBound...])
+        }
+
+        let lowercase = handle.lowercased()
+        if lowercase.hasPrefix("www.") {
+            handle = String(handle.dropFirst(4))
+        } else if lowercase.hasPrefix("m.") {
+            handle = String(handle.dropFirst(2))
+        }
+
+        let instagramDomain = "instagram.com"
+        let shortDomain = "instagr.am"
+        let loweredAfterPrefix = handle.lowercased()
+        if loweredAfterPrefix.hasPrefix(instagramDomain) {
+            handle = String(handle.dropFirst(instagramDomain.count))
+        } else if loweredAfterPrefix.hasPrefix(shortDomain) {
+            handle = String(handle.dropFirst(shortDomain.count))
+        }
+
+        handle = handle.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        if let queryIndex = handle.firstIndex(of: "?") {
+            handle = String(handle[..<queryIndex])
+        }
+
+        if let fragmentIndex = handle.firstIndex(of: "#") {
+            handle = String(handle[..<fragmentIndex])
+        }
+
+        if handle.hasPrefix("@") {
+            handle.removeFirst()
+        }
+
+        return handle.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
 }

--- a/LSE Now/Views/AddEventView.swift
+++ b/LSE Now/Views/AddEventView.swift
@@ -107,7 +107,7 @@ struct AddEventView: View {
                         Text("Contact")
                         Spacer()
                         if let c = contact {
-                            Text("\(c.type): \(c.value)")
+                            Text("\(c.type): \(c.displayValue)")
                                 .foregroundColor(.secondary)
                                 .lineLimit(1)
                         } else {

--- a/LSE Now/Views/EventContactView.swift
+++ b/LSE Now/Views/EventContactView.swift
@@ -29,6 +29,10 @@ struct EventContactView: View {
                         .keyboardType(.emailAddress)
                         .autocapitalization(.none)
                         .textInputAutocapitalization(.never)
+                } else if selectedType == "Instagram" {
+                    TextField("Instagram username (e.g. @society)", text: $value)
+                        .autocapitalization(.none)
+                        .textInputAutocapitalization(.never)
                 } else {
                     TextField("Paste link to the account or post", text: $value)
                         .autocapitalization(.none)
@@ -41,16 +45,21 @@ struct EventContactView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
-                    contact = ContactInfo(type: selectedType, value: value)
+                    let sanitized = ContactInfo.sanitizedValue(for: selectedType, rawValue: value)
+                    contact = ContactInfo(type: selectedType, value: sanitized)
                     dismiss()   // 👈 closes and goes back automatically
                 }
             }
         }
         .onAppear {
             if let c = contact {
-                selectedType = c.type
-                value = c.value
+                selectedType = normalizedType(c.type)
+                value = ContactInfo.displayValue(for: selectedType, storedValue: c.value)
             }
         }
+    }
+
+    private func normalizedType(_ incoming: String) -> String {
+        types.first(where: { $0.lowercased() == incoming.lowercased() }) ?? incoming
     }
 }

--- a/LSE Now/Views/PostDetailView.swift
+++ b/LSE Now/Views/PostDetailView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MapKit
+import UIKit
 
 struct PostDetailView: View {
     let post: Post
@@ -36,24 +37,7 @@ struct PostDetailView: View {
 
                 // --- Organization
                 if let org = post.organization, !org.isEmpty {
-                    Text("by \(org)")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                }
-
-                // --- Contact
-                if let contact = post.contact {
-                    Button {
-                        handleContact(contact)
-                    } label: {
-                        HStack {
-                            Image(systemName: contactIcon(for: contact.type))
-                                .foregroundColor(Color("LSERed"))
-                            Text("\(contact.type): \(contact.value)")
-                                .foregroundColor(.blue)
-                                .underline()
-                        }
-                    }
+                    organizationView(name: org, contact: post.contact)
                 }
 
                 Divider()
@@ -67,9 +51,7 @@ struct PostDetailView: View {
 
                 // --- Description (plain text)
                 if let desc = post.description, !desc.isEmpty {
-                    Text(desc)
-                        .font(.body)
-                        .fixedSize(horizontal: false, vertical: true)
+                    descriptionView(for: desc)
                 }
 
                 // --- Get Directions (moved here)
@@ -102,6 +84,53 @@ struct PostDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
+    @ViewBuilder
+    private func organizationView(name: String, contact: ContactInfo?) -> some View {
+        if let contact {
+            Button {
+                handleContact(contact)
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: contactIcon(for: contact.type))
+                        .foregroundColor(Color("LSERed"))
+                    Text("by \(name)")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                        .underline()
+                    Spacer()
+                }
+            }
+            .buttonStyle(.plain)
+        } else {
+            Text("by \(name)")
+                .font(.headline)
+                .foregroundColor(.primary)
+        }
+    }
+
+    @ViewBuilder
+    private func descriptionView(for text: String) -> some View {
+        Text(attributedDescription(from: text))
+            .font(.body)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func attributedDescription(from text: String) -> AttributedString {
+        let attributed = NSMutableAttributedString(string: text)
+
+        if let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) {
+            let range = NSRange(location: 0, length: attributed.length)
+            detector.enumerateMatches(in: text, options: [], range: range) { match, _, _ in
+                guard let match, let url = match.url else { return }
+                attributed.addAttribute(.link, value: url, range: match.range)
+                attributed.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: match.range)
+                attributed.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: match.range)
+            }
+        }
+
+        return AttributedString(attributed)
+    }
+
     // MARK: - Open Apple Maps
     private func openInMaps(latitude: Double, longitude: Double, name: String) {
         let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
@@ -125,7 +154,7 @@ struct PostDetailView: View {
                 UIApplication.shared.open(url)
             }
         case "instagram":
-            if let url = URL(string: "https://instagram.com/\(contact.value)") {
+            if let url = instagramURL(from: contact.value) {
                 UIApplication.shared.open(url)
             }
         case "facebook":
@@ -152,6 +181,25 @@ struct PostDetailView: View {
         case "email": return "envelope.fill"
         default: return "person.crop.circle"
         }
+    }
+
+    private func instagramURL(from value: String) -> URL? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed), let scheme = url.scheme, !scheme.isEmpty {
+            return url
+        }
+
+        let lower = trimmed.lowercased()
+        if lower.hasPrefix("instagram.com") || lower.hasPrefix("www.instagram.com") ||
+            lower.hasPrefix("instagr.am") || lower.hasPrefix("www.instagr.am") {
+            return URL(string: "https://\(trimmed)")
+        }
+
+        let handle = ContactInfo.sanitizedValue(for: "instagram", rawValue: trimmed)
+        guard !handle.isEmpty else { return nil }
+        return URL(string: "https://instagram.com/\(handle)")
     }
 
 }


### PR DESCRIPTION
## Summary
- sanitize Instagram handles when saving contact info so entries like @username or instagram.com links are converted to a consistent stored value
- show the Instagram-specific placeholder and formatted @handle when editing or reviewing contact details
- build Instagram URLs from the stored handle (including short domains) before opening the organization contact link in the event detail view

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc2964e5c08322a3b74153cc84db99