### PR TITLE
Fix map picker change observation and update post map

### DIFF
--- a/LSE Now/Views/AddEventView.swift
+++ b/LSE Now/Views/AddEventView.swift
@@ -59,27 +59,33 @@ struct AddEventView: View {
                     DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
                 }
 
-                // Location (no autocomplete)
-                TextField("Location", text: $locationQuery)
-                    .modifier(ValidationHighlight(isInvalid: invalidFields.contains("location")))
-                    .focused($focusedField, equals: "location")
-
-                // Map Pin
+                // Location & Map Pin
                 NavigationLink {
-                    ConfirmEventSpotView { coordinate in
+                    ConfirmEventSpotView(
+                        initialCoordinate: pickedCoordinate,
+                        locationText: $locationQuery
+                    ) { coordinate in
                         pickedCoordinate = coordinate
                     }
                 } label: {
                     HStack {
                         Text("Map Pin")
-                        if pickedCoordinate != nil {
-                            Spacer()
+                        Spacer()
+                        if !locationQuery.isEmpty {
+                            Text(locationQuery)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.trailing)
+                                .lineLimit(2)
+                                .font(.callout)
+                        } else if pickedCoordinate != nil {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundColor(.green)
                         }
                     }
                 }
-                .modifier(ValidationHighlight(isInvalid: invalidFields.contains("mapPin")))
+                .modifier(ValidationHighlight(
+                    isInvalid: invalidFields.contains("mapPin") || invalidFields.contains("location")
+                ))
 
                 // Category
                 NavigationLink {

--- a/LSE Now/Views/ConfirmEventSpotView.swift
+++ b/LSE Now/Views/ConfirmEventSpotView.swift
@@ -1,20 +1,29 @@
 import SwiftUI
 import MapKit
+import CoreLocation
 
 struct ConfirmEventSpotView: View {
+    @Binding var locationText: String
     @State private var region: MKCoordinateRegion
-    @State private var hasConfirmed = false
+    @State private var searchError: String?
+    @State private var geocodeWorkItem: DispatchWorkItem?
+    @State private var shouldSkipNextReverseGeocode = false
+    @State private var isGeocoding = false
+    @FocusState private var isAddressFieldFocused: Bool
+
+    private let geocoder = CLGeocoder()
     let initialCoordinate: CLLocationCoordinate2D?
     let onConfirm: (CLLocationCoordinate2D) -> Void
-    
+
     @Environment(\.dismiss) var dismiss
-    
+
     init(initialCoordinate: CLLocationCoordinate2D? = nil,
+         locationText: Binding<String>,
          onConfirm: @escaping (CLLocationCoordinate2D) -> Void) {
         self.initialCoordinate = initialCoordinate
         self.onConfirm = onConfirm
-        
-        // If we already have a coordinate, start from it
+        self._locationText = locationText
+
         if let coord = initialCoordinate {
             _region = State(initialValue: MKCoordinateRegion(
                 center: coord,
@@ -27,40 +36,242 @@ struct ConfirmEventSpotView: View {
             ))
         }
     }
-    
+
     var body: some View {
         VStack(spacing: 16) {
-            Text(hasConfirmed ? "Selected Location" : "Select Event Location")
-                .font(.headline)
-            
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Select Event Location")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                Text("Search for an address or drag the map to drop the pin.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 8) {
+                TextField("Search for an address", text: $locationText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .submitLabel(.search)
+                    .autocorrectionDisabled(true)
+                    .textInputAutocapitalization(.words)
+                    .focused($isAddressFieldFocused)
+                    .onSubmit { searchForAddress() }
+
+                Button {
+                    searchForAddress()
+                } label: {
+                    if isGeocoding {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                    } else {
+                        Image(systemName: "magnifyingglass")
+                    }
+                }
+                .frame(width: 44, height: 44)
+                .background(Color(.systemGray5))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .disabled(locationText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isGeocoding)
+            }
+
+            if let searchError {
+                Text(searchError)
+                    .font(.footnote)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             ZStack {
                 Map(coordinateRegion: $region)
-                    .frame(height: 400)
+                    .frame(height: 360)
                     .cornerRadius(12)
                     .shadow(radius: 3)
-                
-                // Apple-like red dot
+
                 Circle()
-                    .fill(Color.red)
-                    .frame(width: 12, height: 12)
+                    .fill(Color("LSERed"))
+                    .frame(width: 14, height: 14)
                     .overlay(
                         Circle().stroke(Color.white, lineWidth: 2)
                     )
+                    .shadow(radius: 1)
             }
-            
+
+            if !locationText.isEmpty {
+                Text(locationText)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Spacer()
+
             Button {
-                hasConfirmed = true
-                onConfirm(region.center)
-                dismiss() // 👈 close the sheet and go back
+                confirmSelection()
             } label: {
-                Text(hasConfirmed ? "Change Pin" : "Confirm")
+                Text("Confirm Location")
+                    .fontWeight(.semibold)
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color("LSERed"))
                     .foregroundColor(.white)
                     .cornerRadius(10)
             }
+            .disabled(isGeocoding)
         }
         .padding()
+        .navigationTitle("Map Pin")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if let coord = initialCoordinate, locationText.isEmpty {
+                reverseGeocode(for: coord)
+            }
+        }
+        .onChange(of: EquatableCoordinate(region.center)) { newCenter in
+            regionCenterChanged(to: newCenter.coordinate)
+        }
+        .onDisappear {
+            geocodeWorkItem?.cancel()
+            geocoder.cancelGeocode()
+        }
+    }
+
+    private func searchForAddress() {
+        let query = locationText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return }
+
+        geocodeWorkItem?.cancel()
+        geocoder.cancelGeocode()
+        isGeocoding = true
+        searchError = nil
+
+        geocoder.geocodeAddressString(query) { placemarks, error in
+            DispatchQueue.main.async {
+                isGeocoding = false
+            }
+
+            if let error = error as? CLError, error.code == .geocodeCanceled {
+                return
+            }
+
+            guard let placemark = placemarks?.first,
+                  let location = placemark.location,
+                  error == nil else {
+                DispatchQueue.main.async {
+                    searchError = "Unable to find that address. Try again."
+                }
+                return
+            }
+
+            let coordinate = location.coordinate
+
+            DispatchQueue.main.async {
+                shouldSkipNextReverseGeocode = true
+                withAnimation {
+                    region = MKCoordinateRegion(
+                        center: coordinate,
+                        span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
+                    )
+                }
+                locationText = formattedAddress(from: placemark)
+                searchError = nil
+            }
+        }
+    }
+
+    private func regionCenterChanged(to newCenter: CLLocationCoordinate2D) {
+        if shouldSkipNextReverseGeocode {
+            shouldSkipNextReverseGeocode = false
+            return
+        }
+
+        geocodeWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem {
+            reverseGeocode(for: newCenter)
+        }
+
+        geocodeWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: workItem)
+    }
+
+    private func reverseGeocode(for coordinate: CLLocationCoordinate2D) {
+        geocoder.cancelGeocode()
+        isGeocoding = true
+        searchError = nil
+
+        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+
+        geocoder.reverseGeocodeLocation(location) { placemarks, error in
+            DispatchQueue.main.async {
+                isGeocoding = false
+            }
+
+            if let error = error as? CLError, error.code == .geocodeCanceled {
+                return
+            }
+
+            DispatchQueue.main.async {
+                if let placemark = placemarks?.first, error == nil {
+                    locationText = formattedAddress(from: placemark)
+                    searchError = nil
+                } else {
+                    searchError = "We couldn't determine an address here."
+                    if locationText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        locationText = fallbackAddress(for: coordinate)
+                    }
+                }
+            }
+        }
+    }
+
+    private func confirmSelection() {
+        let coordinate = region.center
+        var trimmed = locationText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            trimmed = fallbackAddress(for: coordinate)
+        }
+        locationText = trimmed
+        onConfirm(coordinate)
+        dismiss()
+    }
+
+    private func formattedAddress(from placemark: CLPlacemark) -> String {
+        let street = [placemark.subThoroughfare, placemark.thoroughfare]
+            .compactMap { $0 }
+            .joined(separator: " ")
+
+        let locality = [placemark.locality, placemark.administrativeArea, placemark.postalCode]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+
+        let country = placemark.country
+
+        let components = [street.isEmpty ? placemark.name : street, locality, country]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+
+        if components.isEmpty {
+            return fallbackAddress(for: placemark.location?.coordinate ?? region.center)
+        }
+
+        return components.joined(separator: ", ")
+    }
+
+    private func fallbackAddress(for coordinate: CLLocationCoordinate2D) -> String {
+        String(format: "Lat %.5f, Lon %.5f", coordinate.latitude, coordinate.longitude)
+    }
+}
+
+private struct EquatableCoordinate: Equatable {
+    let latitude: CLLocationDegrees
+    let longitude: CLLocationDegrees
+
+    init(_ coordinate: CLLocationCoordinate2D) {
+        self.latitude = coordinate.latitude
+        self.longitude = coordinate.longitude
+    }
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
 }

--- a/LSE Now/Views/PostDetailView.swift
+++ b/LSE Now/Views/PostDetailView.swift
@@ -67,11 +67,15 @@ struct PostDetailView: View {
 
                 // --- Map Preview
                 if let lat = post.latitude, let lon = post.longitude {
-                    Map(coordinateRegion: .constant(MKCoordinateRegion(
-                        center: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+                    let coordinate = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+                    let region = MKCoordinateRegion(
+                        center: coordinate,
                         span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
-                    )), annotationItems: [CLLocationCoordinate2D(latitude: lat, longitude: lon)]) { coord in
-                        MapMarker(coordinate: coord, tint: .red)
+                    )
+
+                    Map(initialPosition: .region(region)) {
+                        Marker(post.title, coordinate: coordinate)
+                            .tint(.red)
                     }
                     .frame(height: 200)
                     .cornerRadius(12)
@@ -202,9 +206,4 @@ struct PostDetailView: View {
         return URL(string: "https://instagram.com/\(handle)")
     }
 
-}
-
-// MARK: - Identifiable helper
-extension CLLocationCoordinate2D: Identifiable {
-    public var id: String { "\(latitude),\(longitude)" }
 }


### PR DESCRIPTION
## Summary
- embed the location text field inside the map pin picker so the address is edited in context
- add forward and reverse geocoding to sync the map pin with typed addresses and vice versa
- surface the chosen address back on the form while keeping location validation tied to the picker
- update map change observation and adopt the Map content builder APIs to resolve build errors

## Testing
- Not run (Xcode tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc737bf46c8322b4ec0c43bb2cee30