### PR TITLE
Improve whiteboard grid handling and decoding

### DIFF
--- a/LSE Now/Models/WhiteboardMessage.swift
+++ b/LSE Now/Models/WhiteboardMessage.swift
@@ -17,6 +17,31 @@ struct WhiteboardMessage: Identifiable, Decodable, Equatable {
         case createdAt
     }
 
+    init(id: Int, message: String, author: String?, senderEmail: String, receiverEmail: String, createdAt: Date?) {
+        self.id = id
+        self.message = message
+        self.author = author
+        self.senderEmail = senderEmail
+        self.receiverEmail = receiverEmail
+        self.createdAt = createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decodeLossyInt(forKey: .id)
+        message = try container.decode(String.self, forKey: .message)
+        author = container.decodeTrimmedStringIfPresent(forKey: .author)
+
+        let rawSender = try container.decode(String.self, forKey: .senderEmail)
+        senderEmail = rawSender.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        let rawReceiver = try container.decode(String.self, forKey: .receiverEmail)
+        receiverEmail = rawReceiver.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        createdAt = container.decodeWhiteboardDateIfPresent(forKey: .createdAt)
+    }
+
     var formattedTimestamp: String {
         guard let createdAt else { return "" }
         return WhiteboardMessage.dateFormatter.string(from: createdAt)

--- a/LSE Now/Models/WhiteboardPin.swift
+++ b/LSE Now/Models/WhiteboardPin.swift
@@ -20,6 +20,33 @@ struct WhiteboardPin: Identifiable, Codable, Equatable {
         case gridCol
         case createdAt
     }
+
+    init(id: Int, emoji: String, text: String, author: String?, creatorEmail: String, gridRow: Int, gridCol: Int, createdAt: Date?) {
+        self.id = id
+        self.emoji = emoji
+        self.text = text
+        self.author = author
+        self.creatorEmail = creatorEmail
+        self.gridRow = gridRow
+        self.gridCol = gridCol
+        self.createdAt = createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decodeLossyInt(forKey: .id)
+        emoji = try container.decode(String.self, forKey: .emoji)
+        text = try container.decode(String.self, forKey: .text)
+        author = container.decodeTrimmedStringIfPresent(forKey: .author)
+
+        let rawCreatorEmail = try container.decode(String.self, forKey: .creatorEmail)
+        creatorEmail = rawCreatorEmail.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        gridRow = try container.decodeLossyInt(forKey: .gridRow)
+        gridCol = try container.decodeLossyInt(forKey: .gridCol)
+        createdAt = container.decodeWhiteboardDateIfPresent(forKey: .createdAt)
+    }
 }
 
 struct WhiteboardCoordinate: Identifiable, Hashable {
@@ -29,4 +56,116 @@ struct WhiteboardCoordinate: Identifiable, Hashable {
     var id: String {
         "\(row)-\(column)"
     }
+}
+
+extension KeyedDecodingContainer {
+    func decodeLossyInt(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+
+        if let stringValue = try? decode(String.self, forKey: key) {
+            let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let intValue = Int(trimmed) {
+                return intValue
+            }
+        }
+
+        throw DecodingError.dataCorruptedError(
+            forKey: key,
+            in: self,
+            debugDescription: "Expected integer value for \(key.stringValue)."
+        )
+    }
+
+    func decodeTrimmedStringIfPresent(forKey key: Key) -> String? {
+        guard contains(key) else { return nil }
+
+        if let stringValue = try? decode(String.self, forKey: key) {
+            return WhiteboardDecoding.sanitized(stringValue)
+        }
+
+        return nil
+    }
+
+    func decodeWhiteboardDateIfPresent(forKey key: Key) -> Date? {
+        guard contains(key) else { return nil }
+
+        if let stringValue = try? decode(String.self, forKey: key) {
+            return WhiteboardDecoding.parseDate(from: stringValue)
+        }
+
+        if let doubleValue = try? decode(Double.self, forKey: key) {
+            return Date(timeIntervalSince1970: doubleValue)
+        }
+
+        if let intValue = try? decode(Int.self, forKey: key) {
+            return Date(timeIntervalSince1970: TimeInterval(intValue))
+        }
+
+        return nil
+    }
+}
+
+enum WhiteboardDecoding {
+    static func sanitized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func parseDate(from rawValue: String?) -> Date? {
+        guard let rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else { return nil }
+
+        if let date = iso8601WithFractional.date(from: trimmed) {
+            return date
+        }
+
+        if let date = iso8601.date(from: trimmed) {
+            return date
+        }
+
+        if let date = extendedFractional.date(from: trimmed) {
+            return date
+        }
+
+        if let date = fallback.date(from: trimmed) {
+            return date
+        }
+
+        return nil
+    }
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static let iso8601WithFractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static let extendedFractional: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    private static let fallback: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 }

--- a/LSE Now/Networking/APIService.swift
+++ b/LSE Now/Networking/APIService.swift
@@ -79,7 +79,7 @@ final class APIService {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        setAuthorizationHeader(on: &request, token: token)
 
         let payload = EventSubmissionPayload(
             title: draft.title,
@@ -113,7 +113,7 @@ final class APIService {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        setAuthorizationHeader(on: &request, token: token)
 
         let data = try await perform(request: request)
         let decoder = JSONDecoder()
@@ -126,7 +126,7 @@ final class APIService {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "DELETE"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        setAuthorizationHeader(on: &request, token: token)
 
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(CancelEventPayload(id: id))
@@ -152,7 +152,7 @@ final class APIService {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        setAuthorizationHeader(on: &urlRequest, token: token)
 
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(request)
@@ -169,7 +169,7 @@ final class APIService {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        setAuthorizationHeader(on: &request, token: token)
 
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(payload)
@@ -192,7 +192,7 @@ final class APIService {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        setAuthorizationHeader(on: &request, token: token)
 
         let data = try await perform(request: request)
         let decoder = JSONDecoder()
@@ -215,6 +215,12 @@ final class APIService {
         }
 
         return data
+    }
+
+    private func setAuthorizationHeader(on request: inout URLRequest, token: String) {
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedToken.isEmpty else { return }
+        request.setValue("Bearer \(trimmedToken)", forHTTPHeaderField: "Authorization")
     }
 
     private func makeFormBody(_ parameters: [String: String]) -> Data? {

--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -9,8 +9,16 @@ struct WhiteboardView: View {
     @State private var replyTarget: WhiteboardPin?
     @State private var showingInbox = false
 
-    private let rows = 7
-    private let columns = 9
+    private let rows = WhiteboardGridConfiguration.rows
+    private let columns = WhiteboardGridConfiguration.columns
+
+    private var activeToken: String? {
+        guard let token = authViewModel.token?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty else {
+            return nil
+        }
+        return token
+    }
 
     var body: some View {
         NavigationStack {
@@ -68,7 +76,7 @@ struct WhiteboardView: View {
                 Text(viewModel.errorMessage ?? "")
             }
             .sheet(item: $addTarget) { coordinate in
-                if let token = authViewModel.token {
+                if let token = activeToken {
                     AddPinSheet(
                         viewModel: viewModel,
                         coordinate: coordinate,
@@ -79,14 +87,14 @@ struct WhiteboardView: View {
                 }
             }
             .sheet(item: $replyTarget) { pin in
-                if let token = authViewModel.token {
+                if let token = activeToken {
                     ReplySheet(viewModel: viewModel, pin: pin, token: token)
                 } else {
                     MissingSessionView()
                 }
             }
             .sheet(isPresented: $showingInbox) {
-                if let token = authViewModel.token {
+                if let token = activeToken {
                     MessagesInboxView(
                         viewModel: inboxViewModel,
                         token: token
@@ -115,7 +123,7 @@ struct WhiteboardView: View {
                 } else {
                     EmptySlotCell()
                         .onTapGesture {
-                            guard authViewModel.token != nil else { return }
+                            guard activeToken != nil else { return }
                             addTarget = coordinate
                         }
                 }
@@ -181,9 +189,6 @@ private struct EmptySlotCell: View {
         VStack {
             Image(systemName: "plus")
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(Color(.tertiaryLabel))
-            Text("Add Pin")
-                .font(.caption)
                 .foregroundColor(Color(.tertiaryLabel))
         }
         .frame(maxWidth: .infinity, minHeight: 82)

--- a/api/pins.php
+++ b/api/pins.php
@@ -33,6 +33,8 @@ function listPins(PDO $pdo): void
     $query = $pdo->query(
         'SELECT id, emoji, text, author, creator_email, grid_row, grid_col, created_at
          FROM pins
+         WHERE grid_row BETWEEN 0 AND 4
+           AND grid_col BETWEEN 0 AND 7
          ORDER BY created_at DESC'
     );
 
@@ -83,7 +85,7 @@ function createPin(PDO $pdo): void
         return;
     }
 
-    if ($gridRow < 0 || $gridRow > 6 || $gridCol < 0 || $gridCol > 8) {
+    if ($gridRow < 0 || $gridRow > 4 || $gridCol < 0 || $gridCol > 7) {
         http_response_code(400);
         echo json_encode(['error' => 'Grid location is out of range.']);
         return;


### PR DESCRIPTION
## Summary
- make whiteboard pin and message decoding resilient to inconsistent date and integer formats to fix loading errors
- trim and validate login tokens before use and when presenting sheets so authorized calls succeed
- shrink the grid to 5x8 across the client and API, filter invalid coordinates, and remove the extra "Add Pin" label

## Testing
- php -l api/pins.php

------
https://chatgpt.com/codex/tasks/task_e_68ccc9c2226483228018dc89b71279f5