### PR TITLE
Adjust whiteboard layout and improve loading stability

### DIFF
--- a/LSE Now/ViewModels/MessagesInboxViewModel.swift
+++ b/LSE Now/ViewModels/MessagesInboxViewModel.swift
@@ -40,14 +40,17 @@ final class MessagesInboxViewModel: ObservableObject {
         isLoading = true
         errorMessage = nil
 
+        defer { isLoading = false }
+
         do {
             let fetched = try await apiService.fetchMessages(folder: folder.serviceFolder, token: token)
             messages = fetched
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            // Ignore cancellations triggered by switching folders or dismissing the sheet.
+        } catch is CancellationError {
+            // Ignore explicit cancellation errors from Swift concurrency.
         } catch {
             errorMessage = error.localizedDescription
-            messages = []
         }
-
-        isLoading = false
     }
 }

--- a/LSE Now/Views/NewEventView.swift
+++ b/LSE Now/Views/NewEventView.swift
@@ -113,9 +113,10 @@ struct MyEventsView: View {
         }
         .navigationTitle("My Events")
         .navigationBarTitleDisplayMode(.inline)
-        .task(id: authViewModel.token) { token in
-            guard let token = token else { return }
-            await viewModel.loadEvents(token: token, reason: .initial)
+        .task(id: authViewModel.token) {
+            if let token = authViewModel.token {
+                await viewModel.loadEvents(token: token, reason: .initial)
+            }
         }
         .onChange(of: viewModel.errorMessage) { message in
             alertMessage = message

--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -107,7 +107,7 @@ struct WhiteboardView: View {
     }
 
     private var whiteboardGrid: some View {
-        let gridColumns = Array(repeating: GridItem(.flexible(minimum: 56, maximum: 120), spacing: 12), count: columns)
+        let gridColumns = Array(repeating: GridItem(.flexible(), spacing: 12), count: columns)
 
         return LazyVGrid(columns: gridColumns, spacing: 12) {
             ForEach(0..<(rows * self.columns), id: \.self) { index in
@@ -145,32 +145,22 @@ private struct WhiteboardPinCell: View {
     let isMine: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(pin.emoji)
-                .font(.system(size: 34))
-
-            Text(pin.text)
-                .font(.footnote)
-                .foregroundColor(.primary)
-                .lineLimit(2)
-
-            if let author = pin.author, !author.isEmpty {
-                Text(author)
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-            }
-        }
-        .frame(maxWidth: .infinity, minHeight: 82, alignment: .leading)
-        .padding(12)
-        .background(
+        ZStack {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color.white)
-        )
+
+            Text(pin.emoji)
+                .font(.system(size: 44))
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(1, contentMode: .fit)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .stroke(isMine ? Color("LSERed") : Color(.separator), lineWidth: isMine ? 2 : 1)
         )
-        .contentShape(Rectangle())
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
     }
@@ -186,23 +176,22 @@ private struct WhiteboardPinCell: View {
 
 private struct EmptySlotCell: View {
     var body: some View {
-        VStack {
-            Image(systemName: "plus")
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(Color(.tertiaryLabel))
-        }
-        .frame(maxWidth: .infinity, minHeight: 82)
-        .padding(12)
-        .background(
+        ZStack {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color.white)
-        )
+
+            Image(systemName: "plus")
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundColor(Color(.tertiaryLabel))
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(1, contentMode: .fit)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .stroke(style: StrokeStyle(lineWidth: 1, dash: [5]))
                 .foregroundColor(Color(.tertiaryLabel))
         )
-        .contentShape(Rectangle())
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityLabel("Add a new pin here")
     }
 }

--- a/api/pins.php
+++ b/api/pins.php
@@ -33,8 +33,8 @@ function listPins(PDO $pdo): void
     $query = $pdo->query(
         'SELECT id, emoji, text, author, creator_email, grid_row, grid_col, created_at
          FROM pins
-         WHERE grid_row BETWEEN 0 AND 4
-           AND grid_col BETWEEN 0 AND 7
+         WHERE grid_row BETWEEN 0 AND 7
+           AND grid_col BETWEEN 0 AND 4
          ORDER BY created_at DESC'
     );
 
@@ -85,7 +85,7 @@ function createPin(PDO $pdo): void
         return;
     }
 
-    if ($gridRow < 0 || $gridRow > 4 || $gridCol < 0 || $gridCol > 7) {
+    if ($gridRow < 0 || $gridRow > 7 || $gridCol < 0 || $gridCol > 4) {
         http_response_code(400);
         echo json_encode(['error' => 'Grid location is out of range.']);
         return;


### PR DESCRIPTION
## Summary
- update the whiteboard grid configuration to use an 8x5 layout and ignore cancellation errors while loading pins
- render square, emoji-only whiteboard cells and update the API bounds to match the new grid
- suppress cancellation errors when fetching inbox messages and adjust the events task trigger to read the token directly

## Testing
- php -l api/pins.php

------
https://chatgpt.com/codex/tasks/task_e_68ccce99cc5883228549343e89053564