### PR TITLE
Refactor ConfirmEventSpotView body for compiler

### DIFF
--- a/LSE Now/Views/ConfirmEventSpotView.swift
+++ b/LSE Now/Views/ConfirmEventSpotView.swift
@@ -58,93 +58,13 @@ struct ConfirmEventSpotView: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Select Event Location")
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                Text("Search for an address or drag the map to drop the pin.")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack(spacing: 8) {
-                TextField("Search for an address", text: $locationText)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .submitLabel(.search)
-                    .autocorrectionDisabled(true)
-                    .textInputAutocapitalization(.words)
-                    .focused($isAddressFieldFocused)
-                    .onSubmit { searchForAddress() }
-
-                Button {
-                    searchForAddress()
-                } label: {
-                    if isGeocoding {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
-                    } else {
-                        Image(systemName: "magnifyingglass")
-                    }
-                }
-                .frame(width: 44, height: 44)
-                .background(Color(.systemGray5))
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .disabled(locationText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isGeocoding)
-            }
-
-            if let searchError {
-                Text(searchError)
-                    .font(.footnote)
-                    .foregroundColor(.red)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
-            ZStack {
-                Map(
-                    position: $cameraPosition,
-                    interactionModes: .all,
-                    showsUserLocation: isLocationAuthorized
-                )
-                .frame(height: 360)
-                .cornerRadius(12)
-                .shadow(radius: 3)
-                .onMapCameraChange { context in
-                    guard let newRegion = context.region else { return }
-                    region = newRegion
-                    regionCenterChanged(to: newRegion.center)
-                }
-
-                Circle()
-                    .fill(Color("LSERed"))
-                    .frame(width: 14, height: 14)
-                    .overlay(
-                        Circle().stroke(Color.white, lineWidth: 2)
-                    )
-                    .shadow(radius: 1)
-            }
-
-            if !locationText.isEmpty {
-                Text(locationText)
-                    .font(.footnote)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
+            headerSection
+            searchSection
+            errorMessage
+            mapContent
+            selectedAddressLabel
             Spacer()
-
-            Button {
-                confirmSelection()
-            } label: {
-                Text("Confirm Location")
-                    .fontWeight(.semibold)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color("LSERed"))
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-            }
-            .disabled(isGeocoding)
+            confirmButton
         }
         .padding()
         .navigationTitle("Map Pin")
@@ -174,6 +94,106 @@ struct ConfirmEventSpotView: View {
                 locationManager.refreshLocation()
             }
         }
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Select Event Location")
+                .font(.title3)
+                .fontWeight(.semibold)
+            Text("Search for an address or drag the map to drop the pin.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var searchSection: some View {
+        HStack(spacing: 8) {
+            TextField("Search for an address", text: $locationText)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .submitLabel(.search)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.words)
+                .focused($isAddressFieldFocused)
+                .onSubmit { searchForAddress() }
+
+            Button {
+                searchForAddress()
+            } label: {
+                if isGeocoding {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
+                } else {
+                    Image(systemName: "magnifyingglass")
+                }
+            }
+            .frame(width: 44, height: 44)
+            .background(Color(.systemGray5))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .disabled(locationText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isGeocoding)
+        }
+    }
+
+    @ViewBuilder
+    private var errorMessage: some View {
+        if let searchError {
+            Text(searchError)
+                .font(.footnote)
+                .foregroundColor(.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var mapContent: some View {
+        ZStack {
+            Map(
+                position: $cameraPosition,
+                interactionModes: .all,
+                showsUserLocation: isLocationAuthorized
+            )
+            .frame(height: 360)
+            .cornerRadius(12)
+            .shadow(radius: 3)
+            .onMapCameraChange { context in
+                guard let newRegion = context.region else { return }
+                region = newRegion
+                regionCenterChanged(to: newRegion.center)
+            }
+
+            Circle()
+                .fill(Color("LSERed"))
+                .frame(width: 14, height: 14)
+                .overlay(
+                    Circle().stroke(Color.white, lineWidth: 2)
+                )
+                .shadow(radius: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var selectedAddressLabel: some View {
+        if !locationText.isEmpty {
+            Text(locationText)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var confirmButton: some View {
+        Button {
+            confirmSelection()
+        } label: {
+            Text("Confirm Location")
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color("LSERed"))
+                .foregroundColor(.white)
+                .cornerRadius(10)
+        }
+        .disabled(isGeocoding)
     }
 
     private func centerOnUserIfAvailable(shouldReverseGeocode: Bool) {


### PR DESCRIPTION
## Summary
- refactor the ConfirmEventSpotView body into smaller helper views to reduce type-checking complexity
- preserve the existing search, map, and confirmation UI structure with clearer organization

## Testing
- not run (requires local iOS build environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd7af1673c8322aa93346dd145e953