### PR TITLE
Update map views for modern MapKit APIs

### DIFF
--- a/LSE Now/Views/ConfirmEventSpotView.swift
+++ b/LSE Now/Views/ConfirmEventSpotView.swift
@@ -89,8 +89,8 @@ struct ConfirmEventSpotView: View {
             centerMap(on: location.coordinate, shouldReverseGeocode: locationText.isEmpty)
             hasCenteredOnUser = true
         }
-        .onChange(of: locationManager.authorizationStatus) { status in
-            if status == .authorizedWhenInUse || status == .authorizedAlways {
+        .onChange(of: locationManager.authorizationStatus) { _, newStatus in
+            if newStatus == .authorizedWhenInUse || newStatus == .authorizedAlways {
                 locationManager.refreshLocation()
             }
         }
@@ -147,18 +147,23 @@ struct ConfirmEventSpotView: View {
 
     private var mapContent: some View {
         ZStack {
-            Map(
-                position: $cameraPosition,
-                interactionModes: .all,
-                showsUserLocation: isLocationAuthorized
-            )
+            Map(position: $cameraPosition, interactionModes: .all) {
+                if isLocationAuthorized {
+                    UserAnnotation()
+                }
+            }
             .frame(height: 360)
             .cornerRadius(12)
             .shadow(radius: 3)
             .onMapCameraChange { context in
-                guard let newRegion = context.region else { return }
+                guard let newRegion = context.region as MKCoordinateRegion? else { return }
                 region = newRegion
                 regionCenterChanged(to: newRegion.center)
+            }
+            .mapControls {
+                if isLocationAuthorized {
+                    MapUserLocationButton()
+                }
             }
 
             Circle()
@@ -351,23 +356,5 @@ struct ConfirmEventSpotView: View {
 
     private func fallbackAddress(for coordinate: CLLocationCoordinate2D) -> String {
         String(format: "Lat %.5f, Lon %.5f", coordinate.latitude, coordinate.longitude)
-    }
-}
-
-private struct LegacyDraggableConfirmMap: View {
-    @Binding var region: MKCoordinateRegion
-    let showsUserLocation: Bool
-    let onRegionChange: (MKCoordinateRegion) -> Void
-
-    var body: some View {
-        Map(
-            coordinateRegion: $region,
-            interactionModes: .all,
-            showsUserLocation: showsUserLocation,
-            userTrackingMode: .constant(.none)
-        )
-        .onChange(of: region) { newValue in
-            onRegionChange(newValue)
-        }
     }
 }


### PR DESCRIPTION
## Summary
- switch the confirmation map to the iOS 17 Map initialiser and add MapKit user location controls
- rebuild the main map view with the modern Map content builder and annotation APIs
- update authorization status observers to use the new two-parameter `onChange` closures
- fix the confirmation map's camera update handler to accept the non-optional region value returned in iOS 17

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd809bacd083228c0208943b80d5bf