### PR TITLE
Add location consent flow and periodic location uploads

### DIFF
--- a/LSE Now/Networking/APIService.swift
+++ b/LSE Now/Networking/APIService.swift
@@ -134,6 +134,27 @@ final class APIService {
         _ = try await perform(request: request)
     }
 
+    func updateUserLocation(latitude: Double, longitude: Double, timestamp: Date, token: String) async throws {
+        let endpoint = baseURL.appendingPathComponent("user_location.php")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        setAuthorizationHeader(on: &request, token: token)
+
+        let payload = LocationUpdatePayload(
+            latitude: latitude,
+            longitude: longitude,
+            timestamp: timestamp
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        request.httpBody = try encoder.encode(payload)
+
+        _ = try await perform(request: request)
+    }
+
     func fetchPins() async throws -> [WhiteboardPin] {
         let endpoint = baseURL.appendingPathComponent("pins.php")
         var request = URLRequest(url: endpoint)
@@ -266,6 +287,12 @@ private struct CancelEventPayload: Encodable {
 
 private struct ErrorResponse: Decodable {
     let error: String
+}
+
+private struct LocationUpdatePayload: Encodable {
+    let latitude: Double
+    let longitude: Double
+    let timestamp: Date
 }
 
 struct CreatePinRequest: Encodable {

--- a/LSE Now/Services/LocationManager.swift
+++ b/LSE Now/Services/LocationManager.swift
@@ -6,13 +6,31 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     @Published var latestLocation: CLLocation?
 
     private let locationManager: CLLocationManager
+    private let apiService: APIService
+    private let userDefaults: UserDefaults
 
-    override init() {
-        let manager = CLLocationManager()
+    private var uploadTimer: Timer?
+    private var tokenProvider: (() -> String?)?
+    private var shouldUploadWhenLocationAvailable = false
+    private var isUploadingLocation = false
+    private var isTrackingUser = false
+    private var isAppActive = true
+
+    private let permissionKey = "lse.now.locationPermissionPrompted"
+    private let locationUploadInterval: TimeInterval = 30
+
+    init(
+        locationManager: CLLocationManager = CLLocationManager(),
+        apiService: APIService = .shared,
+        userDefaults: UserDefaults = .standard
+    ) {
+        let manager = locationManager
         manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
         manager.distanceFilter = 10
 
         self.locationManager = manager
+        self.apiService = apiService
+        self.userDefaults = userDefaults
         self.authorizationStatus = manager.authorizationStatus
 
         super.init()
@@ -20,12 +38,19 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         manager.delegate = self
     }
 
+    deinit {
+        stopUploadTimer()
+    }
+
     func requestPermission() {
+        hasPromptedForPermission = true
+
         switch locationManager.authorizationStatus {
         case .notDetermined:
             locationManager.requestWhenInUseAuthorization()
         case .authorizedWhenInUse, .authorizedAlways:
             locationManager.startUpdatingLocation()
+            locationManager.requestLocation()
         default:
             break
         }
@@ -42,6 +67,52 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         }
     }
 
+    func handleLoginStateChange(isLoggedIn: Bool, tokenProvider: (() -> String?)?) {
+        DispatchQueue.main.async {
+            if isLoggedIn {
+                self.isTrackingUser = true
+                self.tokenProvider = tokenProvider
+
+                if !self.hasPromptedForPermission {
+                    self.requestPermission()
+                } else {
+                    self.startLocationUpdatesIfAuthorized()
+                }
+
+                self.startUploadTimerIfNeeded()
+
+                if let location = self.latestLocation {
+                    self.shouldUploadWhenLocationAvailable = false
+                    self.sendLocationUpdate(using: location)
+                } else {
+                    self.shouldUploadWhenLocationAvailable = true
+                    self.refreshLocation()
+                }
+            } else {
+                self.isTrackingUser = false
+                self.tokenProvider = nil
+                self.shouldUploadWhenLocationAvailable = false
+                self.stopUploadTimer()
+                self.locationManager.stopUpdatingLocation()
+            }
+        }
+    }
+
+    func updateAppActivity(isActive: Bool) {
+        DispatchQueue.main.async {
+            self.isAppActive = isActive
+
+            if isActive {
+                if self.isTrackingUser {
+                    self.handleUploadTimerFired()
+                    self.startUploadTimerIfNeeded()
+                }
+            } else {
+                self.stopUploadTimer()
+            }
+        }
+    }
+
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
 
@@ -51,6 +122,9 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             switch status {
             case .authorizedWhenInUse, .authorizedAlways:
                 self.locationManager.startUpdatingLocation()
+                if self.isTrackingUser {
+                    self.locationManager.requestLocation()
+                }
             default:
                 self.locationManager.stopUpdatingLocation()
                 self.latestLocation = nil
@@ -59,14 +133,94 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let coordinate = locations.last else { return }
+        guard let location = locations.last else { return }
 
         DispatchQueue.main.async {
-            self.latestLocation = coordinate
+            self.latestLocation = location
+
+            if self.shouldUploadWhenLocationAvailable {
+                self.shouldUploadWhenLocationAvailable = false
+                self.sendLocationUpdate(using: location)
+            }
         }
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         print("Location manager error: \(error.localizedDescription)")
+    }
+
+    private var hasPromptedForPermission: Bool {
+        get { userDefaults.bool(forKey: permissionKey) }
+        set { userDefaults.set(newValue, forKey: permissionKey) }
+    }
+
+    private func startLocationUpdatesIfAuthorized() {
+        switch locationManager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            locationManager.startUpdatingLocation()
+            locationManager.requestLocation()
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        default:
+            break
+        }
+    }
+
+    private func startUploadTimerIfNeeded() {
+        guard uploadTimer == nil, isTrackingUser, isAppActive else { return }
+
+        let timer = Timer.scheduledTimer(withTimeInterval: locationUploadInterval, repeats: true) { [weak self] _ in
+            self?.handleUploadTimerFired()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        uploadTimer = timer
+    }
+
+    private func handleUploadTimerFired() {
+        guard isTrackingUser else { return }
+
+        if let location = latestLocation {
+            sendLocationUpdate(using: location)
+            locationManager.requestLocation()
+        } else {
+            shouldUploadWhenLocationAvailable = true
+            refreshLocation()
+        }
+    }
+
+    private func stopUploadTimer() {
+        uploadTimer?.invalidate()
+        uploadTimer = nil
+    }
+
+    private func sendLocationUpdate(using location: CLLocation) {
+        guard let tokenClosure = tokenProvider, let token = tokenClosure() else { return }
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedToken.isEmpty else { return }
+
+        guard !isUploadingLocation else { return }
+
+        isUploadingLocation = true
+        shouldUploadWhenLocationAvailable = false
+
+        let coordinate = location.coordinate
+        let timestamp = Date()
+
+        Task {
+            do {
+                try await apiService.updateUserLocation(
+                    latitude: coordinate.latitude,
+                    longitude: coordinate.longitude,
+                    timestamp: timestamp,
+                    token: trimmedToken
+                )
+            } catch {
+                print("Failed to update user location: \(error.localizedDescription)")
+            }
+
+            await MainActor.run {
+                self.isUploadingLocation = false
+            }
+        }
     }
 }

--- a/LSE Now/Views/MapView.swift
+++ b/LSE Now/Views/MapView.swift
@@ -88,8 +88,14 @@ struct MapView: View {
     @ViewBuilder
     private var mapLayer: some View {
         Map(position: $cameraPosition, interactionModes: .all) {
-            if isLocationAuthorized {
-                UserAnnotation()
+            if let userCoordinate = locationManager.latestLocation?.coordinate, isLocationAuthorized {
+                Annotation("Current Location", coordinate: userCoordinate) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 10, height: 10)
+                        .overlay(Circle().stroke(Color.white, lineWidth: 2))
+                }
+                .annotationTitles(.hidden)
             }
 
             ForEach(annotatedPosts, id: \.post.id) { entry in

--- a/api/user_location.php
+++ b/api/user_location.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/whiteboard_helpers.php';
+
+header('Content-Type: application/json');
+
+$method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
+
+if ($method !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed.']);
+    exit;
+}
+
+try {
+    $token = extractBearerToken();
+    if ($token === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Authentication required.']);
+        exit;
+    }
+
+    $user = findUserByToken($pdo, $token);
+    if ($user === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid login token.']);
+        exit;
+    }
+
+    $payload = decodeJsonPayload();
+    if ($payload === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid JSON payload.']);
+        exit;
+    }
+
+    $latitude = $payload['latitude'] ?? null;
+    $longitude = $payload['longitude'] ?? null;
+    $timestampRaw = $payload['timestamp'] ?? null;
+
+    if (!is_numeric($latitude) || !is_numeric($longitude)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Latitude and longitude are required.']);
+        exit;
+    }
+
+    if (!is_string($timestampRaw) || $timestampRaw === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'A timestamp is required.']);
+        exit;
+    }
+
+    try {
+        $timestamp = new DateTimeImmutable($timestampRaw);
+    } catch (Exception $exception) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid timestamp.']);
+        exit;
+    }
+
+    $recordedAt = $timestamp->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+    $stmt = $pdo->prepare(
+        'INSERT INTO user_locations (user_id, latitude, longitude, recorded_at)
+         VALUES (:user_id, :latitude, :longitude, :recorded_at)
+         ON DUPLICATE KEY UPDATE
+             latitude = VALUES(latitude),
+             longitude = VALUES(longitude),
+             recorded_at = VALUES(recorded_at),
+             updated_at = CURRENT_TIMESTAMP'
+    );
+
+    $stmt->execute([
+        ':user_id' => $user['id'],
+        ':latitude' => (float) $latitude,
+        ':longitude' => (float) $longitude,
+        ':recorded_at' => $recordedAt,
+    ]);
+
+    echo json_encode(['success' => true]);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Unexpected server error.']);
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -11,6 +11,16 @@ CREATE TABLE IF NOT EXISTS users (
     INDEX idx_users_login_token (login_token)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS user_locations (
+    user_id INT UNSIGNED PRIMARY KEY,
+    latitude DECIMAL(10,7) NOT NULL,
+    longitude DECIMAL(10,7) NOT NULL,
+    recorded_at DATETIME NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_user_locations_user FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS events (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Summary
- prompt for location access only after a user logs in and drive periodic uploads of their coordinates from the location manager
- render the signed-in user's current position as a red dot on the map
- add a backend endpoint, schema table, and client API call to persist user location updates

## Testing
- php -l api/user_location.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb2eba5dc8322986ae26fe326e1ad