### PR TITLE
Restore provided LocationManager implementation

### DIFF
--- a/LSE Now/Networking/APIService.swift
+++ b/LSE Now/Networking/APIService.swift
@@ -134,6 +134,27 @@ final class APIService {
         _ = try await perform(request: request)
     }
 
+    func updateUserLocation(latitude: Double, longitude: Double, timestamp: Date, token: String) async throws {
+        let endpoint = baseURL.appendingPathComponent("user_location.php")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        setAuthorizationHeader(on: &request, token: token)
+
+        let payload = LocationUpdatePayload(
+            latitude: latitude,
+            longitude: longitude,
+            timestamp: timestamp
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        request.httpBody = try encoder.encode(payload)
+
+        _ = try await perform(request: request)
+    }
+
     func fetchPins() async throws -> [WhiteboardPin] {
         let endpoint = baseURL.appendingPathComponent("pins.php")
         var request = URLRequest(url: endpoint)
@@ -266,6 +287,12 @@ private struct CancelEventPayload: Encodable {
 
 private struct ErrorResponse: Decodable {
     let error: String
+}
+
+private struct LocationUpdatePayload: Encodable {
+    let latitude: Double
+    let longitude: Double
+    let timestamp: Date
 }
 
 struct CreatePinRequest: Encodable {

--- a/LSE Now/Services/LocationManager.swift
+++ b/LSE Now/Services/LocationManager.swift
@@ -2,17 +2,35 @@ import Foundation
 import CoreLocation
 
 final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
-    @Published var authorizationStatus: CLAuthorizationStatus
-    @Published var latestLocation: CLLocation?
+    @Published private(set) var authorizationStatus: CLAuthorizationStatus
+    @Published private(set) var latestLocation: CLLocation?
 
     private let locationManager: CLLocationManager
+    private let apiService: APIService
+    private let userDefaults: UserDefaults
 
-    override init() {
-        let manager = CLLocationManager()
+    private var uploadTimer: Timer?
+    private var tokenProvider: (() -> String?)?
+    private var shouldUploadWhenLocationAvailable = false
+    private var isUploadingLocation = false
+    private var isTrackingUser = false
+    private var isAppActive = true
+
+    private let permissionKey = "lse.now.locationPermissionPrompted"
+    private let locationUploadInterval: TimeInterval = 30
+
+    init(
+        locationManager: CLLocationManager = CLLocationManager(),
+        apiService: APIService = .shared,
+        userDefaults: UserDefaults = .standard
+    ) {
+        let manager = locationManager
         manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
         manager.distanceFilter = 10
 
         self.locationManager = manager
+        self.apiService = apiService
+        self.userDefaults = userDefaults
         self.authorizationStatus = manager.authorizationStatus
 
         super.init()
@@ -20,20 +38,174 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         manager.delegate = self
     }
 
+    deinit {
+        stopUploadTimer()
+    }
+
+    // MARK: - Permissions
     func requestPermission() {
+        hasPromptedForPermission = true
         switch locationManager.authorizationStatus {
         case .notDetermined:
+            log("Asking user for when-in-use authorization")
             locationManager.requestWhenInUseAuthorization()
         case .authorizedWhenInUse, .authorizedAlways:
+            log("Permission already granted; starting location updates")
             locationManager.startUpdatingLocation()
+            locationManager.requestLocation()
         default:
-            break
+            log("Permission request not performed because status is \(describeAuthorizationStatus(status: locationManager.authorizationStatus))")
         }
     }
 
     func refreshLocation() {
-        switch locationManager.authorizationStatus {
+        let status = locationManager.authorizationStatus
+        log("Refreshing location with authorization status \(describeAuthorizationStatus(status: status))")
+
+        switch status {
         case .authorizedWhenInUse, .authorizedAlways:
+            log("Requesting a one-time location update")
+            locationManager.requestLocation()
+        case .notDetermined:
+            log("Authorization not determined; requesting permission")
+            locationManager.requestWhenInUseAuthorization()
+        default:
+            log("Skipping location refresh (status = \(describeAuthorizationStatus(status: status)))")
+        }
+    }
+
+    // MARK: - Login & Activity
+    func handleLoginStateChange(isLoggedIn: Bool, tokenProvider: (() -> String?)?) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.log("Login state changed. isLoggedIn: \(isLoggedIn)")
+
+            if isLoggedIn {
+                self.isTrackingUser = true
+                self.tokenProvider = tokenProvider
+
+                if !self.hasPromptedForPermission {
+                    self.log("Prompting user for location permission")
+                    self.requestPermission()
+                } else {
+                    self.startLocationUpdatesIfAuthorized()
+                }
+
+                if let location = self.latestLocation {
+                    self.log("Sending immediate location update with cached coordinates")
+                    self.shouldUploadWhenLocationAvailable = false
+                    self.sendLocationUpdate(using: location)
+                } else {
+                    let status = self.locationManager.authorizationStatus
+                    self.shouldUploadWhenLocationAvailable = true
+
+                    switch status {
+                    case .authorizedWhenInUse, .authorizedAlways:
+                        self.log("Requesting location update now that user is logged in")
+                        self.refreshLocation()
+                    case .notDetermined:
+                        self.log("Waiting for user to grant permission before refreshing location")
+                    default:
+                        self.log("Cannot refresh location because authorization is \(self.describeAuthorizationStatus(status: status))")
+                    }
+                }
+
+                self.startUploadTimerIfNeeded()
+            } else {
+                self.log("Stopping tracking due to logout")
+                self.isTrackingUser = false
+                self.tokenProvider = nil
+                self.shouldUploadWhenLocationAvailable = false
+                self.isUploadingLocation = false
+                self.stopUploadTimer()
+                self.locationManager.stopUpdatingLocation()
+                self.latestLocation = nil
+            }
+        }
+    }
+
+    func updateAppActivity(isActive: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.isAppActive = isActive
+            self.log("App activity updated. isActive: \(isActive)")
+
+            if isActive {
+                if self.isTrackingUser {
+                    self.log("App active while tracking; trigger upload")
+                    self.handleUploadTimerFired()
+                }
+                self.startUploadTimerIfNeeded()
+            } else {
+                self.log("App moved to background; stopping upload timer")
+                self.stopUploadTimer()
+            }
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.latestLocation = location
+            self.log("Received location update at \(location.timestamp)")
+
+            if self.shouldUploadWhenLocationAvailable {
+                self.log("Uploading deferred location update")
+                self.shouldUploadWhenLocationAvailable = false
+                self.sendLocationUpdate(using: location)
+            }
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        log("Location manager error: \(error.localizedDescription)")
+    }
+
+    @available(iOS 14.0, *)
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        handleAuthorizationChange(to: manager.authorizationStatus)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        handleAuthorizationChange(to: status)
+    }
+
+    private func handleAuthorizationChange(to status: CLAuthorizationStatus) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.authorizationStatus = status
+            self.log("Authorization status changed to \(self.describeAuthorizationStatus(status: status))")
+
+            switch status {
+            case .authorizedWhenInUse, .authorizedAlways:
+                self.locationManager.startUpdatingLocation()
+                if self.isTrackingUser {
+                    self.locationManager.requestLocation()
+                }
+            default:
+                self.locationManager.stopUpdatingLocation()
+                self.latestLocation = nil
+            }
+        }
+    }
+
+    // MARK: - Location Updates
+    private var hasPromptedForPermission: Bool {
+        get { userDefaults.bool(forKey: permissionKey) }
+        set { userDefaults.set(newValue, forKey: permissionKey) }
+    }
+
+    private func startLocationUpdatesIfAuthorized() {
+        let status = locationManager.authorizationStatus
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
+            locationManager.startUpdatingLocation()
             locationManager.requestLocation()
         case .notDetermined:
             locationManager.requestWhenInUseAuthorization()
@@ -42,31 +214,98 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         }
     }
 
-    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        let status = manager.authorizationStatus
+    // MARK: - Upload Timer
+    private func startUploadTimerIfNeeded() {
+        guard uploadTimer == nil, isTrackingUser, isAppActive else { return }
 
-        DispatchQueue.main.async {
-            self.authorizationStatus = status
+        log("Starting upload timer every \(locationUploadInterval) seconds")
+        let timer = Timer.scheduledTimer(withTimeInterval: locationUploadInterval, repeats: true) { [weak self] _ in
+            self?.handleUploadTimerFired()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        uploadTimer = timer
+    }
 
-            switch status {
-            case .authorizedWhenInUse, .authorizedAlways:
-                self.locationManager.startUpdatingLocation()
-            default:
-                self.locationManager.stopUpdatingLocation()
-                self.latestLocation = nil
+    private func handleUploadTimerFired() {
+        guard isTrackingUser else { return }
+
+        if let location = latestLocation {
+            sendLocationUpdate(using: location)
+            locationManager.requestLocation()
+        } else {
+            shouldUploadWhenLocationAvailable = true
+            let status = locationManager.authorizationStatus
+            if status == .authorizedWhenInUse || status == .authorizedAlways {
+                refreshLocation()
+            } else {
+                log("Upload timer fired but authorization is \(describeAuthorizationStatus(status: status)); awaiting permission")
             }
         }
     }
 
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let coordinate = locations.last else { return }
+    private func stopUploadTimer() {
+        if uploadTimer != nil {
+            log("Stopping upload timer")
+        }
+        uploadTimer?.invalidate()
+        uploadTimer = nil
+    }
 
-        DispatchQueue.main.async {
-            self.latestLocation = coordinate
+    // MARK: - Send Location
+    private func sendLocationUpdate(using location: CLLocation) {
+        guard let tokenClosure = tokenProvider, let token = tokenClosure() else {
+            log("No token available for location update")
+            return
+        }
+
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedToken.isEmpty else {
+            log("Token is empty after trimming")
+            return
+        }
+
+        guard !isUploadingLocation else {
+            log("Upload already in progress")
+            return
+        }
+
+        isUploadingLocation = true
+        shouldUploadWhenLocationAvailable = false
+
+        let coordinate = location.coordinate
+        let timestamp = Date()
+        log("Sending location update to server (lat: \(coordinate.latitude), lon: \(coordinate.longitude)) at \(timestamp)")
+
+        Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                try await self.apiService.updateUserLocation(
+                    latitude: coordinate.latitude,
+                    longitude: coordinate.longitude,
+                    timestamp: timestamp,
+                    token: trimmedToken
+                )
+                self.log("Successfully sent location update")
+            } catch {
+                self.log("Failed to send location: \(error.localizedDescription)")
+            }
+            await MainActor.run { self.isUploadingLocation = false }
         }
     }
 
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print("Location manager error: \(error.localizedDescription)")
+    // MARK: - Helpers
+    private func log(_ message: String) {
+        print("[LocationManager] \(message)")
+    }
+
+    private func describeAuthorizationStatus(status: CLAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined: return "not determined"
+        case .restricted: return "restricted"
+        case .denied: return "denied"
+        case .authorizedAlways: return "authorized always"
+        case .authorizedWhenInUse: return "authorized when in use"
+        @unknown default: return "unknown (\(status.rawValue))"
+        }
     }
 }

--- a/LSE Now/Views/MapView.swift
+++ b/LSE Now/Views/MapView.swift
@@ -88,8 +88,14 @@ struct MapView: View {
     @ViewBuilder
     private var mapLayer: some View {
         Map(position: $cameraPosition, interactionModes: .all) {
-            if isLocationAuthorized {
-                UserAnnotation()
+            if let userCoordinate = locationManager.latestLocation?.coordinate, isLocationAuthorized {
+                Annotation("Current Location", coordinate: userCoordinate) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 10, height: 10)
+                        .overlay(Circle().stroke(Color.white, lineWidth: 2))
+                }
+                .annotationTitles(.hidden)
             }
 
             ForEach(annotatedPosts, id: \.post.id) { entry in

--- a/api/user_location.php
+++ b/api/user_location.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/whiteboard_helpers.php';
+
+header('Content-Type: application/json');
+
+$method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
+
+if ($method !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed.']);
+    exit;
+}
+
+try {
+    $token = extractBearerToken();
+    if ($token === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Authentication required.']);
+        exit;
+    }
+
+    $user = findUserByToken($pdo, $token);
+    if ($user === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid login token.']);
+        exit;
+    }
+
+    $payload = decodeJsonPayload();
+    if ($payload === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid JSON payload.']);
+        exit;
+    }
+
+    $latitude = $payload['latitude'] ?? null;
+    $longitude = $payload['longitude'] ?? null;
+    $timestampRaw = $payload['timestamp'] ?? null;
+
+    if (!is_numeric($latitude) || !is_numeric($longitude)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Latitude and longitude are required.']);
+        exit;
+    }
+
+    if (!is_string($timestampRaw) || $timestampRaw === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'A timestamp is required.']);
+        exit;
+    }
+
+    try {
+        $timestamp = new DateTimeImmutable($timestampRaw);
+    } catch (Exception $exception) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid timestamp.']);
+        exit;
+    }
+
+    $recordedAt = $timestamp->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+    $stmt = $pdo->prepare(
+        'INSERT INTO user_locations (user_id, latitude, longitude, recorded_at)
+         VALUES (:user_id, :latitude, :longitude, :recorded_at)
+         ON DUPLICATE KEY UPDATE
+             latitude = VALUES(latitude),
+             longitude = VALUES(longitude),
+             recorded_at = VALUES(recorded_at),
+             updated_at = CURRENT_TIMESTAMP'
+    );
+
+    $stmt->execute([
+        ':user_id' => $user['id'],
+        ':latitude' => (float) $latitude,
+        ':longitude' => (float) $longitude,
+        ':recorded_at' => $recordedAt,
+    ]);
+
+    echo json_encode(['success' => true]);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Unexpected server error.']);
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -11,6 +11,16 @@ CREATE TABLE IF NOT EXISTS users (
     INDEX idx_users_login_token (login_token)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS user_locations (
+    user_id INT UNSIGNED PRIMARY KEY,
+    latitude DECIMAL(10,7) NOT NULL,
+    longitude DECIMAL(10,7) NOT NULL,
+    recorded_at DATETIME NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_user_locations_user FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS events (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Summary
- replace `LocationManager` with the provided implementation while keeping login, activity, and upload coordination intact
- avoid triggering a location refresh while authorization is still undetermined to prevent repeated permission prompts
- gate periodic refresh attempts on authorization status so timers wait for consent before requesting locations

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cdb2eba5dc8322986ae26fe326e1ad