### PR TITLE
Normalize pin authors and improve pinboard refresh

### DIFF
--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -173,16 +173,20 @@ struct WhiteboardView: View {
     private func refreshPins() async {
         let minimumDuration: TimeInterval = 1
         let start = Date()
-        await viewModel.loadPins()
+        print("🔄 Refreshing Pinboard…")
+        await viewModel.loadPins(forceReload: true)
 
         guard !Task.isCancelled else { return }
 
         let elapsed = Date().timeIntervalSince(start)
         let remaining = minimumDuration - elapsed
-        guard remaining > 0 else { return }
+        if remaining > 0 {
+            let delay = UInt64((remaining * 1_000_000_000).rounded())
+            try? await Task.sleep(nanoseconds: delay)
+        }
 
-        let delay = UInt64((remaining * 1_000_000_000).rounded())
-        try? await Task.sleep(nanoseconds: delay)
+        let totalDuration = Date().timeIntervalSince(start)
+        print(String(format: "✅ Pinboard refresh completed in %.2fs", totalDuration))
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure whiteboard pins always display the creator's email as the author by normalizing the model after fetches and submissions
- make whiteboard refreshes wait for in-flight loads when necessary, reuse the new normalization, and keep expiration timers in sync
- enhance the Pinboard pull-to-refresh by forcing a reload, guaranteeing the minimum spinner duration, and emitting debug logs

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68cde4a576d88322a851794a25deaaae