### PR TITLE
Ensure Pinboard refresh fetches latest pins

### DIFF
--- a/LSE Now/ViewModels/WhiteboardViewModel.swift
+++ b/LSE Now/ViewModels/WhiteboardViewModel.swift
@@ -53,7 +53,9 @@ final class WhiteboardViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
-            let fetchedPins = try await apiService.fetchPins()
+            let fetchedPins = try await apiService.fetchPins(
+                cacheBustingToken: forceReload ? UUID().uuidString : nil
+            )
             let normalizedPins = fetchedPins
                 .filter { WhiteboardGridConfiguration.contains(row: $0.gridRow, column: $0.gridCol) }
                 .map { pinWithCreatorAuthor($0) }


### PR DESCRIPTION
## Summary
- add optional cache-busting token to the pin fetch API request and disable HTTP caching when provided
- include a cache-busting token whenever the Pinboard refresh is forced so the UI always pulls fresh data

## Testing
- not run (iOS project in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdeb5162cc832282c2b1eee67f9413