### PR TITLE
Revamp launch animation with zooming beaver

### DIFF
--- a/LSE Now/Views/BeaverFaceView.swift
+++ b/LSE Now/Views/BeaverFaceView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct BeaverFaceView: View {
+    var body: some View {
+        GeometryReader { proxy in
+            let size = min(proxy.size.width, proxy.size.height)
+            let headColor = Color(red: 0.60, green: 0.39, blue: 0.23)
+            let muzzleColor = Color(red: 0.82, green: 0.65, blue: 0.50)
+            let noseColor = Color(red: 0.32, green: 0.22, blue: 0.17)
+            let earSize = size * 0.38
+            let earOffset = size * 0.45
+            let whiskerColor = Color.white.opacity(0.75)
+
+            ZStack {
+                Group {
+                    Circle()
+                        .fill(headColor)
+                        .frame(width: earSize, height: earSize)
+                        .offset(x: -earOffset, y: -earOffset * 1.05)
+                    Circle()
+                        .fill(headColor)
+                        .frame(width: earSize, height: earSize)
+                        .offset(x: earOffset, y: -earOffset * 1.05)
+                }
+
+                Circle()
+                    .fill(headColor)
+                    .frame(width: size * 0.95, height: size * 0.95)
+                    .offset(y: size * 0.08)
+                    .shadow(color: Color.black.opacity(0.12), radius: size * 0.08, y: size * 0.03)
+
+                RoundedRectangle(cornerRadius: size * 0.35, style: .continuous)
+                    .fill(muzzleColor)
+                    .frame(width: size * 0.75, height: size * 0.5)
+                    .offset(y: size * 0.32)
+
+                HStack(spacing: size * 0.22) {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: size * 0.22)
+                        .overlay(
+                            Circle()
+                                .fill(Color.black)
+                                .frame(width: size * 0.1)
+                                .offset(x: size * 0.02, y: size * 0.02)
+                        )
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: size * 0.22)
+                        .overlay(
+                            Circle()
+                                .fill(Color.black)
+                                .frame(width: size * 0.1)
+                                .offset(x: size * 0.02, y: size * 0.02)
+                        )
+                }
+                .offset(y: -size * 0.05)
+
+                RoundedRectangle(cornerRadius: size * 0.2, style: .continuous)
+                    .fill(noseColor)
+                    .frame(width: size * 0.22, height: size * 0.14)
+                    .offset(y: size * 0.12)
+
+                RoundedRectangle(cornerRadius: size * 0.05, style: .continuous)
+                    .fill(Color.white)
+                    .frame(width: size * 0.24, height: size * 0.24)
+                    .offset(y: size * 0.56)
+                    .overlay(
+                        Rectangle()
+                            .fill(Color(red: 0.86, green: 0.86, blue: 0.86))
+                            .frame(width: size * 0.02, height: size * 0.24)
+                    )
+
+                Group {
+                    VStack(spacing: size * 0.1) {
+                        Capsule()
+                            .fill(whiskerColor)
+                            .frame(width: size * 0.45, height: size * 0.035)
+                        Capsule()
+                            .fill(whiskerColor)
+                            .frame(width: size * 0.45, height: size * 0.035)
+                    }
+                    .offset(x: -size * 0.46, y: size * 0.32)
+                    .rotationEffect(.degrees(-5))
+
+                    VStack(spacing: size * 0.1) {
+                        Capsule()
+                            .fill(whiskerColor)
+                            .frame(width: size * 0.45, height: size * 0.035)
+                        Capsule()
+                            .fill(whiskerColor)
+                            .frame(width: size * 0.45, height: size * 0.035)
+                    }
+                    .offset(x: size * 0.46, y: size * 0.32)
+                    .rotationEffect(.degrees(5))
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+        }
+    }
+}
+

--- a/LSE Now/Views/LaunchView.swift
+++ b/LSE Now/Views/LaunchView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct LaunchView: View {
     @State private var animate = false
     @State private var finished = false
+    @State private var zooming = false
+    @State private var fadeBackground = false
+    @State private var hideLaunchContent = false
     @StateObject private var viewModel = PostListViewModel() // preload in background
     @StateObject private var authViewModel = AuthViewModel()
     @EnvironmentObject private var locationManager: LocationManager
@@ -10,25 +13,17 @@ struct LaunchView: View {
 
     var body: some View {
         ZStack {
-            if finished {
-                if authViewModel.isLoggedIn {
-                    MainTabView(viewModel: viewModel) // pass loaded VM forward
-                        .environmentObject(authViewModel)
-                } else {
-                    LoginFlowView(viewModel: authViewModel)
-                }
+            if authViewModel.isLoggedIn {
+                MainTabView(viewModel: viewModel) // pass loaded VM forward
+                    .environmentObject(authViewModel)
             } else {
-                Color("LSERed")
-                    .ignoresSafeArea()
+                LoginFlowView(viewModel: authViewModel)
+            }
 
-                VStack {
-                    Text("BeavR")
-                        .font(.custom("HelveticaNeue-Bold", size: 44))
-                        .foregroundColor(.white)
-                        .scaleEffect(animate ? 1.0 : 0.8)
-                        .opacity(animate ? 1.0 : 0.0)
-                        .animation(.easeOut(duration: 1.0), value: animate)
-                }
+            if !finished {
+                launchOverlay
+                    .transition(.opacity)
+                    .zIndex(1)
             }
         }
         .onAppear {
@@ -48,10 +43,27 @@ struct LaunchView: View {
             // Kick off animation
             animate = true
 
-            // Transition to app after ~2 seconds
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                withAnimation(.easeInOut(duration: 0.5)) {
-                    finished = true
+            // Transition to app after ~2 seconds with a zoom + fade sequence
+            let zoomDelay = 2.0
+            let zoomDuration = 0.7
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + zoomDelay) {
+                withAnimation(.easeInOut(duration: zoomDuration)) {
+                    zooming = true
+                    fadeBackground = true
+                }
+
+                let contentFadeDelay = zoomDuration * 0.6
+                DispatchQueue.main.asyncAfter(deadline: .now() + contentFadeDelay) {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        hideLaunchContent = true
+                    }
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + zoomDuration + 0.2) {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        finished = true
+                    }
                 }
             }
         }
@@ -67,6 +79,33 @@ struct LaunchView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             locationManager.updateAppActivity(isActive: newPhase == .active)
+        }
+    }
+
+    private var launchOverlay: some View {
+        ZStack {
+            Color("LSERed")
+                .opacity(fadeBackground ? 0.0 : 1.0)
+                .ignoresSafeArea()
+                .animation(.easeInOut(duration: 0.7), value: fadeBackground)
+
+            VStack(spacing: 28) {
+                BeaverFaceView()
+                    .frame(width: 180, height: 180)
+                    .scaleEffect(zooming ? 7.5 : (animate ? 1.0 : 0.8))
+                    .animation(.easeOut(duration: 1.0), value: animate)
+                    .animation(.easeInOut(duration: 0.7), value: zooming)
+
+                Text("BeavR")
+                    .font(.custom("HelveticaNeue-Bold", size: 44))
+                    .foregroundColor(.white)
+                    .opacity(zooming ? 0.0 : (animate ? 1.0 : 0.0))
+                    .scaleEffect(animate ? 1.0 : 0.8)
+                    .animation(.easeOut(duration: 1.0), value: animate)
+                    .animation(.easeInOut(duration: 0.3), value: zooming)
+            }
+            .opacity(hideLaunchContent ? 0.0 : 1.0)
+            .animation(.easeInOut(duration: 0.3), value: hideLaunchContent)
         }
     }
 }


### PR DESCRIPTION
## Summary
- overlay the launch screen on top of the main content so the transition can fade into the app
- add a zoom-and-fade sequence that scales the mascot and fades the red background as loading completes
- introduce a custom `BeaverFaceView` SwiftUI component to draw the beaver face for the launch animation

## Testing
- not run (Xcode tooling is unavailable in this container)


------
https://chatgpt.com/codex/tasks/task_e_68ce9baab984832288eea4c4e630883f