### PR TITLE
Ensure pin author defaults to logged-in email

### DIFF
--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -436,17 +436,28 @@ private struct AddPinSheet: View {
 
         guard !trimmedEmoji.isEmpty, !trimmedText.isEmpty else { return }
 
+        let normalizedEmail = (authViewModel.loggedInEmail ?? authViewModel.email)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        let resolvedAuthor: String?
+        if !trimmedAuthor.isEmpty {
+            resolvedAuthor = trimmedAuthor
+        } else if !normalizedEmail.isEmpty {
+            resolvedAuthor = normalizedEmail
+        } else {
+            resolvedAuthor = nil
+        }
+
         Task {
             do {
                 try await viewModel.createPin(
                     emoji: trimmedEmoji,
                     text: trimmedText,
-                    author: trimmedAuthor.isEmpty ? nil : trimmedAuthor,
+                    author: resolvedAuthor,
                     at: coordinate,
                     token: token,
-                    creatorEmail: (authViewModel.loggedInEmail ?? authViewModel.email)
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .lowercased()
+                    creatorEmail: normalizedEmail.isEmpty ? nil : normalizedEmail
                 )
                 dismiss()
             } catch {


### PR DESCRIPTION
## Summary
- default new pins' author field to the authenticated user's email when no custom name is provided
- reuse the normalized login email when updating local pin state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cea04f68e08322802c5689bd280ab5