### PR TITLE
Ensure pin creation payload includes creator email

### DIFF
--- a/LSE Now/Networking/APIService.swift
+++ b/LSE Now/Networking/APIService.swift
@@ -386,6 +386,7 @@ struct CreatePinRequest: Encodable {
     let emoji: String
     let text: String
     let author: String?
+    let creatorEmail: String
     let gridRow: Int
     let gridCol: Int
 }


### PR DESCRIPTION
## Summary
- normalize and require the creator email before attempting to create a pin
- include the creatorEmail field in the pin creation payload sent to the API
- surface a clear error when the creator email is missing so users can retry after logging in

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68cefdcac9ac8322bd540aa29b312699