### PR TITLE
Stop showing creator email on pins

### DIFF
--- a/LSE Now/ViewModels/WhiteboardViewModel.swift
+++ b/LSE Now/ViewModels/WhiteboardViewModel.swift
@@ -211,12 +211,18 @@ final class WhiteboardViewModel: ObservableObject {
         let sanitizedAuthor = WhiteboardDecoding.sanitized(pin.author)
 
         let finalAuthor: String?
-        if let sanitizedAuthor, !sanitizedAuthor.isEmpty {
-            finalAuthor = sanitizedAuthor
-        } else if normalizedCreator.isEmpty {
-            finalAuthor = nil
+        if let sanitizedAuthor {
+            let normalizedAuthor = sanitizedAuthor
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+
+            if !normalizedCreator.isEmpty && normalizedAuthor == normalizedCreator {
+                finalAuthor = nil
+            } else {
+                finalAuthor = sanitizedAuthor
+            }
         } else {
-            finalAuthor = normalizedCreator
+            finalAuthor = nil
         }
 
         return WhiteboardPin(

--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -436,8 +436,6 @@ private struct AddPinSheet: View {
         let resolvedAuthor: String?
         if !trimmedAuthor.isEmpty {
             resolvedAuthor = trimmedAuthor
-        } else if !normalizedEmail.isEmpty {
-            resolvedAuthor = normalizedEmail
         } else {
             resolvedAuthor = nil
         }


### PR DESCRIPTION
## Summary
- stop defaulting new pin authors to the creator's email when none is provided
- avoid showing the creator email as the author when normalizing pin data

## Testing
- not run (iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf00485f688322b14c73d155d1d205