### PR TITLE
Implement push notification support and admin tools

### DIFF
--- a/BeavR.xcodeproj/project.pbxproj
+++ b/BeavR.xcodeproj/project.pbxproj
@@ -34,8 +34,9 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Assets.xcassets,
-				LSE_NowApp.swift,
-				Models/ContactInfo.swift,
+                                AppDelegate.swift,
+                                LSE_NowApp.swift,
+                                Models/ContactInfo.swift,
 				Models/Post.swift,
 				"Models/Post+Display.swift",
 				"Models/Post+Status.swift",
@@ -44,8 +45,9 @@
 				Models/WhiteboardPin.swift,
 				Networking/APIService.swift,
 				Services/LocationManager.swift,
-				Services/LocationSearchCompleter.swift,
-				Services/TokenStorage.swift,
+                                Services/LocationSearchCompleter.swift,
+                                Services/PushNotificationManager.swift,
+                                Services/TokenStorage.swift,
 				Services/WhiteboardSeenPinsStore.swift,
 				ViewModels/AuthViewModel.swift,
 				ViewModels/MessagesInboxViewModel.swift,
@@ -81,8 +83,9 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Assets.xcassets,
-				LSE_NowApp.swift,
-				"LSE-Now-Info.plist",
+                                AppDelegate.swift,
+                                LSE_NowApp.swift,
+                                "LSE-Now-Info.plist",
 			);
 			target = 9AE9E1752E7B34B9005D3827 /* LSE NowUITests */;
 		};
@@ -98,8 +101,9 @@
 				Models/WhiteboardPin.swift,
 				Networking/APIService.swift,
 				Services/LocationManager.swift,
-				Services/LocationSearchCompleter.swift,
-				Services/TokenStorage.swift,
+                                Services/LocationSearchCompleter.swift,
+                                Services/PushNotificationManager.swift,
+                                Services/TokenStorage.swift,
 				Services/WhiteboardSeenPinsStore.swift,
 				ViewModels/AuthViewModel.swift,
 				ViewModels/MessagesInboxViewModel.swift,

--- a/LSE Now/AppDelegate.swift
+++ b/LSE Now/AppDelegate.swift
@@ -1,0 +1,33 @@
+import UIKit
+import UserNotifications
+
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        PushNotificationManager.shared.applicationDidFinishLaunching()
+        return true
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        PushNotificationManager.shared.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        PushNotificationManager.shared.didFailToRegisterForRemoteNotifications(error: error)
+    }
+
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        let handled = PushNotificationManager.shared.handleRemoteNotification(userInfo: userInfo)
+        completionHandler(handled ? .newData : .noData)
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        PushNotificationManager.shared.handleForegroundNotification(userInfo: notification.request.content.userInfo)
+        completionHandler([.list, .banner, .sound])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        PushNotificationManager.shared.handleRemoteNotification(userInfo: response.notification.request.content.userInfo)
+        completionHandler()
+    }
+}

--- a/LSE Now/LSE_NowApp.swift
+++ b/LSE Now/LSE_NowApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct LSE_NowApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var locationManager = LocationManager()
 
     var body: some Scene {

--- a/LSE Now/Services/PushNotificationManager.swift
+++ b/LSE Now/Services/PushNotificationManager.swift
@@ -1,0 +1,219 @@
+import Foundation
+import UIKit
+import UserNotifications
+
+final class PushNotificationManager: NSObject {
+    static let shared = PushNotificationManager()
+    static let messageReplyReceivedNotification = Notification.Name("PushNotificationManager.didReceiveMessageReply")
+
+    private let apiService: APIService
+    private let tokenStorage: TokenStorage
+
+    private var cachedAuthToken: String?
+    private var cachedEmail: String?
+    private var currentDeviceToken: String?
+    private var isRegisteredOnServer = false
+
+    private var registrationTask: Task<Void, Never>?
+    private var unregistrationTask: Task<Void, Never>?
+
+    private override init() {
+        self.apiService = .shared
+        self.tokenStorage = .shared
+        super.init()
+
+        cachedAuthToken = tokenStorage.loadToken()?.trimmingCharacters(in: .whitespacesAndNewlines)
+        cachedEmail = tokenStorage.loadEmail()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    func applicationDidFinishLaunching() {
+        if cachedAuthToken != nil, cachedEmail != nil {
+            requestAuthorizationIfNeeded()
+            registerDeviceTokenIfPossible(force: true)
+        }
+    }
+
+    func resumeSession(email: String, authToken: String, shouldRequestAuthorization: Bool = false) {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedToken = authToken.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        DispatchQueue.main.async {
+            self.cachedEmail = normalizedEmail
+            self.cachedAuthToken = normalizedToken
+            self.isRegisteredOnServer = false
+
+            if shouldRequestAuthorization {
+                self.requestAuthorizationIfNeeded()
+            }
+
+            self.registerDeviceTokenIfPossible(force: shouldRequestAuthorization)
+        }
+    }
+
+    func handleSuccessfulLogin(email: String, authToken: String) {
+        resumeSession(email: email, authToken: authToken, shouldRequestAuthorization: true)
+    }
+
+    func handleLogout(email _: String, authToken: String) {
+        let normalizedToken = authToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedToken.isEmpty else {
+            clearCachedCredentials()
+            return
+        }
+
+        DispatchQueue.main.async {
+            let deviceToken = self.currentDeviceToken
+            self.clearCachedCredentials()
+
+            guard let token = deviceToken else { return }
+
+            self.unregistrationTask?.cancel()
+            self.unregistrationTask = Task { [weak self] in
+                do {
+                    try await self?.apiService.unregisterNotificationDevice(deviceToken: token, authToken: normalizedToken)
+                } catch {
+                    print("⚠️ [Push] Failed to unregister device token: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    func didRegisterForRemoteNotifications(deviceToken: Data) {
+        let tokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
+        DispatchQueue.main.async {
+            self.currentDeviceToken = tokenString
+            self.isRegisteredOnServer = false
+            self.registerDeviceTokenIfPossible(force: true)
+        }
+    }
+
+    func didFailToRegisterForRemoteNotifications(error: Error) {
+        print("⚠️ [Push] Remote notification registration failed: \(error.localizedDescription)")
+    }
+
+    @discardableResult
+    func handleRemoteNotification(userInfo: [AnyHashable: Any]) -> Bool {
+        guard let type = userInfo["type"] as? String else { return false }
+
+        if type == "message.reply" {
+            NotificationCenter.default.post(name: Self.messageReplyReceivedNotification, object: nil, userInfo: userInfo)
+            return true
+        }
+
+        return false
+    }
+
+    func handleForegroundNotification(userInfo: [AnyHashable: Any]) {
+        _ = handleRemoteNotification(userInfo: userInfo)
+    }
+
+    // MARK: - Private helpers
+
+    private func requestAuthorizationIfNeeded() {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { [weak self] settings in
+            guard let self else { return }
+
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                    self.registerDeviceTokenIfPossible(force: false)
+                }
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+                    if let error {
+                        print("⚠️ [Push] Authorization request failed: \(error.localizedDescription)")
+                    }
+
+                    guard granted else { return }
+                    DispatchQueue.main.async { [weak self] in
+                        UIApplication.shared.registerForRemoteNotifications()
+                        self?.registerDeviceTokenIfPossible(force: true)
+                    }
+                }
+            case .denied:
+                print("⚠️ [Push] Notifications are disabled in Settings.")
+            default:
+                break
+            }
+        }
+    }
+
+    private func registerDeviceTokenIfPossible(force: Bool) {
+        DispatchQueue.main.async {
+            guard let deviceToken = self.currentDeviceToken,
+                  let authToken = self.cachedAuthToken,
+                  let email = self.cachedEmail,
+                  !deviceToken.isEmpty,
+                  !authToken.isEmpty,
+                  !email.isEmpty else {
+                return
+            }
+
+            if self.isRegisteredOnServer && !force {
+                return
+            }
+
+            let appVersion = self.currentAppVersion()
+            let osVersion = UIDevice.current.systemVersion
+            let environment = Self.currentEnvironment
+
+            self.registrationTask?.cancel()
+            self.registrationTask = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.apiService.registerNotificationDevice(
+                        token: deviceToken,
+                        environment: environment,
+                        appVersion: appVersion,
+                        osVersion: osVersion,
+                        authToken: authToken
+                    )
+
+                    await MainActor.run {
+                        self.isRegisteredOnServer = true
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.isRegisteredOnServer = false
+                    }
+                    print("⚠️ [Push] Failed to register device: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func clearCachedCredentials() {
+        cachedEmail = nil
+        cachedAuthToken = nil
+        isRegisteredOnServer = false
+        registrationTask?.cancel()
+        registrationTask = nil
+    }
+
+    private func currentAppVersion() -> String? {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String
+        let build = info?["CFBundleVersion"] as? String
+
+        switch (version, build) {
+        case let (version?, build?):
+            return "\(version) (\(build))"
+        case let (version?, nil):
+            return version
+        case let (nil, build?):
+            return build
+        default:
+            return nil
+        }
+    }
+
+    private static var currentEnvironment: String {
+        #if DEBUG
+        return "sandbox"
+        #else
+        return "production"
+        #endif
+    }
+}

--- a/LSE Now/Views/WhiteboardMessagesInboxView.swift
+++ b/LSE Now/Views/WhiteboardMessagesInboxView.swift
@@ -35,6 +35,12 @@ struct MessagesInboxView: View {
             .task(id: selectedFolder) {
                 await viewModel.fetchMessages(folder: selectedFolder, token: token)
             }
+            .onReceive(NotificationCenter.default.publisher(for: PushNotificationManager.messageReplyReceivedNotification)) { _ in
+                guard selectedFolder == .received else { return }
+                Task {
+                    await viewModel.fetchMessages(folder: .received, token: token)
+                }
+            }
             .alert(
                 "Unable to Load Messages",
                 isPresented: Binding(

--- a/Server (API and admin)/admin/dashboard.php
+++ b/Server (API and admin)/admin/dashboard.php
@@ -76,6 +76,7 @@ switch ($tab) {
         <a href="?tab=old" <?= $tab === "old" ? "style='color:red'" : "" ?>>Old</a>
         <a href="?tab=map" <?= $tab === "map" ? "style='color:red'" : "" ?>>Live Users Map</a>
         <a href="?tab=users" <?= $tab === "users" ? "style='color:red'" : "" ?>>Live Users</a>
+        <a href="notifications.php">Notifications</a>
         <a href="logout.php" style="float:right">Logout</a>
     </nav>
 

--- a/Server (API and admin)/admin/notifications.php
+++ b/Server (API and admin)/admin/notifications.php
@@ -1,0 +1,204 @@
+<?php
+session_start();
+if (!isset($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../services/NotificationService.php';
+
+$pdo = getPDO();
+$service = new NotificationService($pdo);
+
+$title = '';
+$body = '';
+$targetEmail = '';
+$extraJson = '';
+$sendAll = false;
+$statusMessage = null;
+$errorMessage = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $body = trim($_POST['body'] ?? '');
+    $targetEmail = strtolower(trim($_POST['target_email'] ?? ''));
+    $sendAll = isset($_POST['send_all']);
+    $extraJson = trim($_POST['extra'] ?? '');
+
+    if ($title === '' || $body === '') {
+        $errorMessage = 'A title and message body are required.';
+    } else {
+        $extraPayload = [];
+        if ($extraJson !== '') {
+            $decoded = json_decode($extraJson, true);
+            if (!is_array($decoded)) {
+                $errorMessage = 'Unable to parse the custom payload. Please provide valid JSON.';
+            } else {
+                $extraPayload = $decoded;
+            }
+        }
+
+        if ($errorMessage === null) {
+            $targets = [];
+            if ($sendAll) {
+                $devices = $service->listActiveDevices();
+                $targets = array_values(array_unique(array_map(
+                    static function (array $device): string {
+                        return strtolower((string) ($device['email'] ?? ''));
+                    },
+                    $devices
+                )));
+                $targets = array_filter($targets, static fn($email) => $email !== '');
+            } else {
+                if ($targetEmail === '') {
+                    $errorMessage = 'Provide a target email or choose "Send to everyone".';
+                } else {
+                    $targets = [$targetEmail];
+                }
+            }
+
+            if ($errorMessage === null && empty($targets)) {
+                $errorMessage = 'No target devices were found for the requested action.';
+            }
+
+            if ($errorMessage === null) {
+                $deliveries = 0;
+                foreach ($targets as $email) {
+                    $deliveries += $service->sendToEmail(
+                        $email,
+                        $title,
+                        $body,
+                        [
+                            'threadId' => 'admin-broadcast',
+                            'category' => 'ADMIN_BROADCAST',
+                            'extra' => array_merge([
+                                'type' => 'admin.broadcast',
+                                'targetEmail' => $email,
+                            ], $extraPayload),
+                            'collapseId' => 'admin_' . substr(sha1($title . $body), 0, 24),
+                        ]
+                    );
+                }
+
+                $statusMessage = sprintf(
+                    'Notification queued for %d user(s); %d device deliveries attempted.',
+                    count($targets),
+                    $deliveries
+                );
+            }
+        }
+    }
+}
+
+$activeDevices = $service->listActiveDevices();
+$apnsConfigured = $service->isApnsConfigured();
+
+function shortToken(string $token): string
+{
+    $clean = preg_replace('/\s+/', '', $token) ?? $token;
+    $length = strlen($clean);
+    if ($length <= 12) {
+        return $clean;
+    }
+    return substr($clean, 0, 6) . '…' . substr($clean, -6);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Notification Broadcasts</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; background: #f7f7f9; }
+        header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+        h1 { margin: 0; }
+        nav a { margin-right: 15px; text-decoration: none; font-weight: bold; }
+        .card { background: #fff; border-radius: 12px; padding: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.08); margin-bottom: 24px; }
+        label { display: block; font-weight: 600; margin-top: 12px; }
+        input[type="text"], textarea { width: 100%; padding: 10px; border-radius: 8px; border: 1px solid #ccc; font-size: 15px; }
+        textarea { min-height: 120px; resize: vertical; }
+        .actions { margin-top: 16px; display: flex; gap: 12px; align-items: center; }
+        button { background: #c8102e; color: white; border: none; padding: 10px 18px; border-radius: 8px; cursor: pointer; font-size: 15px; }
+        button:hover { background: #a80d25; }
+        table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+        th, td { padding: 10px; border-bottom: 1px solid #e3e3e3; text-align: left; }
+        th { background: #fafafa; }
+        .status { padding: 12px 16px; border-radius: 8px; margin-bottom: 18px; }
+        .status.success { background: #e6f4ea; color: #1e7c36; border: 1px solid #a6d6b5; }
+        .status.error { background: #fceaea; color: #c1121f; border: 1px solid #f5b5b5; }
+        .badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; background: #eef0f4; margin-left: 6px; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Push Notifications</h1>
+        <nav>
+            <a href="dashboard.php">&larr; Back to dashboard</a>
+            <a href="logout.php">Logout</a>
+        </nav>
+    </header>
+
+    <section class="card">
+        <h2>Send Notification</h2>
+        <p>APNs configuration status: <strong><?= $apnsConfigured ? 'Ready' : 'Missing credentials' ?></strong></p>
+
+        <?php if ($statusMessage): ?>
+            <div class="status success"><?= htmlspecialchars($statusMessage, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+        <?php if ($errorMessage): ?>
+            <div class="status error"><?= htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+
+        <form method="post">
+            <label for="title">Title</label>
+            <input type="text" id="title" name="title" value="<?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8') ?>" required>
+
+            <label for="body">Message</label>
+            <textarea id="body" name="body" required><?= htmlspecialchars($body, ENT_QUOTES, 'UTF-8') ?></textarea>
+
+            <label for="target_email">Target email</label>
+            <input type="text" id="target_email" name="target_email" value="<?= htmlspecialchars($targetEmail, ENT_QUOTES, 'UTF-8') ?>" placeholder="student@lse.ac.uk">
+
+            <label for="extra">Optional JSON payload</label>
+            <textarea id="extra" name="extra" placeholder='{"url":"https://..."}'><?= htmlspecialchars($extraJson, ENT_QUOTES, 'UTF-8') ?></textarea>
+
+            <div class="actions">
+                <label><input type="checkbox" name="send_all" value="1" <?= $sendAll ? 'checked' : '' ?>> Send to everyone with an active device</label>
+            </div>
+
+            <button type="submit">Send push notification</button>
+        </form>
+    </section>
+
+    <section class="card">
+        <h2>Active Devices <span class="badge"><?= count($activeDevices) ?></span></h2>
+        <?php if (empty($activeDevices)): ?>
+            <p>No active devices have registered for notifications yet.</p>
+        <?php else: ?>
+            <table>
+                <tr>
+                    <th>Email</th>
+                    <th>Token</th>
+                    <th>Platform</th>
+                    <th>Environment</th>
+                    <th>App Version</th>
+                    <th>OS Version</th>
+                    <th>Last Seen</th>
+                </tr>
+                <?php foreach ($activeDevices as $device): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($device['email'] ?? '', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars(shortToken((string) ($device['device_token'] ?? '')), ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars($device['platform'] ?? 'ios', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars($device['environment'] ?? 'production', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars($device['app_version'] ?? '-', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars($device['os_version'] ?? '-', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars($device['updated_at'] ?? '-', ENT_QUOTES, 'UTF-8') ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </table>
+        <?php endif; ?>
+    </section>
+</body>
+</html>

--- a/Server (API and admin)/api/notification_tokens.php
+++ b/Server (API and admin)/api/notification_tokens.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../services/NotificationService.php';
+require_once __DIR__ . '/whiteboard_helpers.php';
+
+header('Content-Type: application/json');
+
+$logFile = __DIR__ . '/../notification_tokens.log';
+
+function logNotificationApi(string $message): void
+{
+    global $logFile;
+    $timestamp = date('Y-m-d H:i:s');
+    file_put_contents($logFile, "[{$timestamp}] {$message}\n", FILE_APPEND);
+}
+
+try {
+    $method = strtoupper($_SERVER['REQUEST_METHOD'] ?? '');
+    switch ($method) {
+        case 'POST':
+            registerNotificationToken($pdo);
+            break;
+        case 'DELETE':
+            deleteNotificationToken($pdo);
+            break;
+        case 'OPTIONS':
+            http_response_code(204);
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode(['error' => 'Method not allowed.']);
+    }
+} catch (Throwable $exception) {
+    logNotificationApi('Unhandled exception: ' . $exception->getMessage());
+    http_response_code(500);
+    echo json_encode(['error' => 'Unexpected server error.']);
+}
+
+function registerNotificationToken(PDO $pdo): void
+{
+    $token = extractBearerToken();
+    if ($token === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Authentication required.']);
+        logNotificationApi('POST rejected: missing bearer token.');
+        return;
+    }
+
+    $user = findUserByToken($pdo, $token);
+    if ($user === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid login token.']);
+        logNotificationApi('POST rejected: invalid token.');
+        return;
+    }
+
+    $payload = decodeJsonPayload();
+    if (!is_array($payload)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid JSON payload.']);
+        logNotificationApi('POST rejected: invalid JSON payload.');
+        return;
+    }
+
+    $deviceToken = trim((string) ($payload['deviceToken'] ?? ''));
+    if ($deviceToken === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'deviceToken is required.']);
+        logNotificationApi('POST rejected: missing deviceToken.');
+        return;
+    }
+
+    $metadata = [
+        'platform' => $payload['platform'] ?? null,
+        'environment' => $payload['environment'] ?? null,
+        'appVersion' => $payload['appVersion'] ?? null,
+        'osVersion' => $payload['osVersion'] ?? null,
+    ];
+
+    $service = new NotificationService($pdo);
+    $service->registerDeviceToken($user['email'], $deviceToken, $metadata);
+
+    http_response_code(201);
+    echo json_encode(['success' => true]);
+    logNotificationApi('POST success: token registered for ' . $user['email']);
+}
+
+function deleteNotificationToken(PDO $pdo): void
+{
+    $token = extractBearerToken();
+    if ($token === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Authentication required.']);
+        logNotificationApi('DELETE rejected: missing bearer token.');
+        return;
+    }
+
+    $user = findUserByToken($pdo, $token);
+    if ($user === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid login token.']);
+        logNotificationApi('DELETE rejected: invalid token.');
+        return;
+    }
+
+    $payload = decodeJsonPayload();
+    if (!is_array($payload)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid JSON payload.']);
+        logNotificationApi('DELETE rejected: invalid JSON payload.');
+        return;
+    }
+
+    $deviceToken = trim((string) ($payload['deviceToken'] ?? ''));
+    if ($deviceToken === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'deviceToken is required.']);
+        logNotificationApi('DELETE rejected: missing deviceToken.');
+        return;
+    }
+
+    $service = new NotificationService($pdo);
+    $service->unregisterDeviceToken($user['email'], $deviceToken);
+
+    http_response_code(200);
+    echo json_encode(['success' => true]);
+    logNotificationApi('DELETE success: token unregistered for ' . $user['email']);
+}

--- a/Server (API and admin)/services/NotificationService.php
+++ b/Server (API and admin)/services/NotificationService.php
@@ -1,0 +1,498 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Lightweight APNs notification helper used by both the API layer and the admin dashboard.
+ */
+final class NotificationService
+{
+    private const PLATFORM_IOS = 'ios';
+    private const VALID_PLATFORMS = [self::PLATFORM_IOS];
+    private const VALID_ENVIRONMENTS = ['sandbox', 'production'];
+
+    private PDO $pdo;
+    private string $logFile;
+
+    private ?string $apnsKeyId;
+    private ?string $apnsTeamId;
+    private ?string $apnsBundleId;
+    private ?string $apnsAuthKey;
+    private bool $apnsUseSandbox;
+
+    /** @var OpenSSLAsymmetricKey|resource|null */
+    private $apnsPrivateKeyResource = null;
+
+    public function __construct(PDO $pdo, array $options = [])
+    {
+        $this->pdo = $pdo;
+        $this->logFile = $options['logFile'] ?? __DIR__ . '/../notifications.log';
+
+        $this->apnsKeyId = $options['apnsKeyId'] ?? getenv('APNS_KEY_ID') ?: null;
+        $this->apnsTeamId = $options['apnsTeamId'] ?? getenv('APNS_TEAM_ID') ?: null;
+        $this->apnsBundleId = $options['apnsBundleId'] ?? getenv('APNS_BUNDLE_ID') ?: null;
+
+        $authKey = $options['apnsAuthKey'] ?? getenv('APNS_AUTH_KEY') ?: null;
+        $authKeyPath = $options['apnsAuthKeyPath'] ?? getenv('APNS_AUTH_KEY_PATH') ?: null;
+        if (($authKey === null || $authKey === '') && $authKeyPath) {
+            $loaded = $this->loadFileIfExists($authKeyPath);
+            if ($loaded !== null) {
+                $authKey = $loaded;
+            }
+        }
+        $this->apnsAuthKey = $authKey ? trim($authKey) : null;
+
+        $sandboxFlag = $options['apnsUseSandbox'] ?? getenv('APNS_USE_SANDBOX');
+        $this->apnsUseSandbox = filter_var($sandboxFlag, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+
+        $this->log('NotificationService initialised. APNs configured=' . ($this->isApnsConfigured() ? 'yes' : 'no'));
+    }
+
+    public function isApnsConfigured(): bool
+    {
+        return $this->apnsKeyId !== null
+            && $this->apnsTeamId !== null
+            && $this->apnsBundleId !== null
+            && $this->apnsAuthKey !== null
+            && $this->apnsAuthKey !== '';
+    }
+
+    public function registerDeviceToken(string $email, string $deviceToken, array $metadata = []): void
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        $normalizedToken = $this->normalizeToken($deviceToken);
+
+        if ($normalizedEmail === '' || $normalizedToken === '') {
+            throw new InvalidArgumentException('Email and device token are required.');
+        }
+
+        $platform = strtolower((string) ($metadata['platform'] ?? self::PLATFORM_IOS));
+        if (!in_array($platform, self::VALID_PLATFORMS, true)) {
+            $platform = self::PLATFORM_IOS;
+        }
+
+        $environment = strtolower((string) ($metadata['environment'] ?? ($this->apnsUseSandbox ? 'sandbox' : 'production')));
+        if (!in_array($environment, self::VALID_ENVIRONMENTS, true)) {
+            $environment = $this->apnsUseSandbox ? 'sandbox' : 'production';
+        }
+
+        $appVersion = $this->sanitizeNullable($metadata['appVersion'] ?? null);
+        $osVersion = $this->sanitizeNullable($metadata['osVersion'] ?? null);
+
+        $sql = <<<SQL
+            INSERT INTO notification_devices (email, device_token, platform, environment, app_version, os_version, is_active, last_used_at)
+            VALUES (:email, :token, :platform, :environment, :appVersion, :osVersion, 1, NOW())
+            ON DUPLICATE KEY UPDATE
+                email = VALUES(email),
+                platform = VALUES(platform),
+                environment = VALUES(environment),
+                app_version = VALUES(app_version),
+                os_version = VALUES(os_version),
+                is_active = 1,
+                updated_at = NOW(),
+                last_used_at = NOW()
+        SQL;
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            ':email' => $normalizedEmail,
+            ':token' => $normalizedToken,
+            ':platform' => $platform,
+            ':environment' => $environment,
+            ':appVersion' => $appVersion,
+            ':osVersion' => $osVersion,
+        ]);
+
+        $this->log("Registered device token for {$normalizedEmail} ({$environment}).");
+    }
+
+    public function unregisterDeviceToken(string $email, string $deviceToken): void
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        $normalizedToken = $this->normalizeToken($deviceToken);
+
+        if ($normalizedEmail === '' || $normalizedToken === '') {
+            return;
+        }
+
+        $sql = 'UPDATE notification_devices SET is_active = 0, updated_at = NOW(), last_used_at = NOW() WHERE device_token = :token AND email = :email';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            ':token' => $normalizedToken,
+            ':email' => $normalizedEmail,
+        ]);
+
+        $this->log("Unregistered device token for {$normalizedEmail}.");
+    }
+
+    public function sendMessageReplyNotification(string $receiverEmail, string $senderEmail, int $pinId, string $messageText, int $messageId): void
+    {
+        $receiver = $this->normalizeEmail($receiverEmail);
+        if ($receiver === '') {
+            return;
+        }
+
+        $senderDescriptor = $this->displayNameForEmail($senderEmail);
+        $title = "New reply from {$senderDescriptor}";
+        $body = $this->truncate($messageText, 140);
+
+        $extra = [
+            'type' => 'message.reply',
+            'pinId' => $pinId,
+            'messageId' => $messageId,
+            'senderEmail' => $this->normalizeEmail($senderEmail),
+        ];
+
+        $options = [
+            'threadId' => 'whiteboard-replies',
+            'category' => 'MESSAGE_REPLY',
+            'contentAvailable' => true,
+            'collapseId' => 'message_reply_' . $pinId,
+            'extra' => $extra,
+        ];
+
+        $sent = $this->sendToEmail($receiver, $title, $body, $options);
+        $this->log("Message reply notification for {$receiver} attempted → {$sent} deliveries queued.");
+    }
+
+    public function sendToEmail(string $email, string $title, string $body, array $options = []): int
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        if ($normalizedEmail === '') {
+            return 0;
+        }
+
+        $devices = $this->fetchActiveDevices($normalizedEmail);
+        if (empty($devices)) {
+            $this->log("No active devices for {$normalizedEmail}, skipping push.");
+            return 0;
+        }
+
+        $payload = $this->buildApnsPayload($title, $body, $options);
+        $collapseId = $options['collapseId'] ?? null;
+        $priority = isset($options['priority']) ? (string) $options['priority'] : '10';
+
+        $sentCount = 0;
+        foreach ($devices as $device) {
+            if (($device['platform'] ?? self::PLATFORM_IOS) !== self::PLATFORM_IOS) {
+                continue;
+            }
+
+            $token = (string) $device['device_token'];
+            $environment = (string) ($device['environment'] ?? ($this->apnsUseSandbox ? 'sandbox' : 'production'));
+
+            if ($this->sendApnsRequest($token, $payload, $environment, $collapseId, $priority)) {
+                $sentCount++;
+                $this->touchDevice($token);
+            }
+        }
+
+        if ($sentCount > 0) {
+            $this->logNotificationRecord($normalizedEmail, $title, $body, $options['extra'] ?? []);
+        }
+
+        return $sentCount;
+    }
+
+    public function listActiveDevices(?string $emailFilter = null): array
+    {
+        $sql = 'SELECT email, device_token, platform, environment, app_version, os_version, updated_at, last_used_at FROM notification_devices WHERE is_active = 1';
+        $params = [];
+
+        if ($emailFilter !== null && $emailFilter !== '') {
+            $sql .= ' AND email = :email';
+            $params[':email'] = $this->normalizeEmail($emailFilter);
+        }
+
+        $sql .= ' ORDER BY updated_at DESC';
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    private function fetchActiveDevices(string $email): array
+    {
+        $stmt = $this->pdo->prepare('SELECT device_token, platform, environment FROM notification_devices WHERE email = :email AND is_active = 1');
+        $stmt->execute([':email' => $email]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    private function touchDevice(string $token): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE notification_devices SET last_used_at = NOW() WHERE device_token = :token');
+        $stmt->execute([':token' => $this->normalizeToken($token)]);
+    }
+
+    private function buildApnsPayload(string $title, string $body, array $options = []): array
+    {
+        $aps = [
+            'alert' => [
+                'title' => $title,
+                'body' => $body,
+            ],
+            'sound' => $options['sound'] ?? 'default',
+        ];
+
+        if (!empty($options['contentAvailable'])) {
+            $aps['content-available'] = 1;
+        }
+
+        if (!empty($options['mutableContent'])) {
+            $aps['mutable-content'] = 1;
+        }
+
+        if (!empty($options['threadId'])) {
+            $aps['thread-id'] = (string) $options['threadId'];
+        }
+
+        if (!empty($options['category'])) {
+            $aps['category'] = (string) $options['category'];
+        }
+
+        if (isset($options['badge'])) {
+            $aps['badge'] = (int) $options['badge'];
+        }
+
+        $payload = ['aps' => $aps];
+
+        if (!empty($options['extra']) && is_array($options['extra'])) {
+            foreach ($options['extra'] as $key => $value) {
+                if ($key === 'aps') {
+                    continue;
+                }
+                $payload[$key] = $value;
+            }
+        }
+
+        return $payload;
+    }
+
+    private function sendApnsRequest(string $deviceToken, array $payload, string $environment, ?string $collapseId, string $priority): bool
+    {
+        if (!$this->isApnsConfigured()) {
+            $this->log('APNs credentials are not configured; skipping remote send.');
+            return false;
+        }
+
+        $jwt = $this->buildJwt();
+        if ($jwt === null) {
+            $this->log('Unable to build APNs JWT; skipping send.');
+            return false;
+        }
+
+        $host = $environment === 'sandbox' ? 'https://api.sandbox.push.apple.com' : 'https://api.push.apple.com';
+        $url = sprintf('%s/3/device/%s', $host, $deviceToken);
+
+        $headers = [
+            'apns-topic: ' . $this->apnsBundleId,
+            'authorization: bearer ' . $jwt,
+            'content-type: application/json',
+            'apns-priority: ' . $priority,
+        ];
+
+        if ($collapseId !== null && $collapseId !== '') {
+            $headers[] = 'apns-collapse-id: ' . $collapseId;
+        }
+
+        $jsonPayload = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($jsonPayload === false) {
+            $this->log('Failed to encode APNs payload: ' . json_last_error_msg());
+            return false;
+        }
+
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => $url,
+            CURLOPT_PORT => 443,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $jsonPayload,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_2_0,
+            CURLOPT_HTTPHEADER => $headers,
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_errno($ch) ? curl_error($ch) : null;
+        curl_close($ch);
+
+        if ($curlError !== null) {
+            $this->log("APNs send failed (curl): {$curlError}");
+            return false;
+        }
+
+        if ($httpCode >= 200 && $httpCode < 300) {
+            $this->log('APNs send succeeded for token ' . $deviceToken);
+            return true;
+        }
+
+        $this->log("APNs send failed ({$httpCode}): {$response}");
+        return false;
+    }
+
+    private function buildJwt(): ?string
+    {
+        $privateKey = $this->getPrivateKeyResource();
+        if (!$privateKey) {
+            return null;
+        }
+
+        $header = ['alg' => 'ES256', 'kid' => $this->apnsKeyId];
+        $claims = ['iss' => $this->apnsTeamId, 'iat' => time()];
+
+        $segments = [
+            $this->base64UrlEncode(json_encode($header)),
+            $this->base64UrlEncode(json_encode($claims)),
+        ];
+
+        if (in_array(null, $segments, true)) {
+            $this->log('Failed to encode APNs JWT header/claims.');
+            return null;
+        }
+
+        $signingInput = implode('.', $segments);
+        $signature = '';
+        $success = openssl_sign($signingInput, $signature, $privateKey, OPENSSL_ALGO_SHA256);
+
+        if (!$success) {
+            $this->log('openssl_sign failed when building APNs JWT.');
+            return null;
+        }
+
+        $segments[] = $this->base64UrlEncode($signature);
+        if (in_array(null, $segments, true)) {
+            $this->log('Failed to encode APNs JWT signature.');
+            return null;
+        }
+
+        return implode('.', $segments);
+    }
+
+    /**
+     * @return OpenSSLAsymmetricKey|resource|null
+     */
+    private function getPrivateKeyResource()
+    {
+        if ($this->apnsPrivateKeyResource !== null) {
+            return $this->apnsPrivateKeyResource;
+        }
+
+        if ($this->apnsAuthKey === null || $this->apnsAuthKey === '') {
+            return null;
+        }
+
+        $keyMaterial = $this->apnsAuthKey;
+        if (strpos($keyMaterial, 'BEGIN PRIVATE KEY') === false) {
+            $decoded = base64_decode($keyMaterial, true);
+            if ($decoded !== false) {
+                $keyMaterial = $decoded;
+            }
+        }
+
+        $resource = openssl_pkey_get_private($keyMaterial);
+        if ($resource === false) {
+            $this->log('Unable to load APNs private key.');
+            return null;
+        }
+
+        $this->apnsPrivateKeyResource = $resource;
+        return $resource;
+    }
+
+    private function logNotificationRecord(string $email, string $title, string $body, array $payload): void
+    {
+        $sql = 'INSERT INTO notification_log (email, title, body, payload) VALUES (:email, :title, :body, :payload)';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            ':email' => $email,
+            ':title' => $title,
+            ':body' => $body,
+            ':payload' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+    }
+
+    private function normalizeEmail(?string $email): string
+    {
+        if ($email === null) {
+            return '';
+        }
+        return strtolower(trim($email));
+    }
+
+    private function normalizeToken(?string $token): string
+    {
+        if ($token === null) {
+            return '';
+        }
+        $stripped = preg_replace('/\s+/', '', $token);
+        return strtolower($stripped ?? '');
+    }
+
+    private function sanitizeNullable($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim((string) $value);
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function truncate(string $text, int $maxLength): string
+    {
+        $trimmed = trim($text);
+        if (mb_strlen($trimmed) <= $maxLength) {
+            return $trimmed;
+        }
+
+        return mb_substr($trimmed, 0, $maxLength - 1) . '…';
+    }
+
+    private function displayNameForEmail(string $email): string
+    {
+        $normalized = $this->normalizeEmail($email);
+        if ($normalized === '') {
+            return 'Someone';
+        }
+
+        $parts = explode('@', $normalized, 2);
+        $local = $parts[0] ?? $normalized;
+        $local = str_replace(['.', '_', '-'], ' ', $local);
+        $local = ucwords($local);
+
+        return $local === '' ? $normalized : $local;
+    }
+
+    private function base64UrlEncode($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $encoded = base64_encode($value);
+        if ($encoded === false) {
+            return null;
+        }
+
+        return rtrim(strtr($encoded, '+/', '-_'), '=');
+    }
+
+    private function loadFileIfExists(string $path): ?string
+    {
+        if (is_file($path) && is_readable($path)) {
+            $contents = file_get_contents($path);
+            if ($contents !== false) {
+                return $contents;
+            }
+        }
+        return null;
+    }
+
+    private function log(string $message): void
+    {
+        $timestamp = date('Y-m-d H:i:s');
+        file_put_contents($this->logFile, "[{$timestamp}] {$message}\n", FILE_APPEND);
+    }
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -166,6 +166,41 @@ CREATE TABLE `user_locations` (
 INSERT INTO `user_locations` (`latitude`, `email`, `longitude`, `recorded_at`, `updated_at`) VALUES
 (51.5163163, 'p.canovari@lse.ac.uk', -0.1248199, '2025-09-20 15:22:33', '2025-09-20 15:23:31');
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `notification_devices`
+--
+
+CREATE TABLE `notification_devices` (
+  `id` int(11) UNSIGNED NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `device_token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `platform` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ios',
+  `environment` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'production',
+  `app_version` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `os_version` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT '1',
+  `last_used_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `notification_log`
+--
+
+CREATE TABLE `notification_log` (
+  `id` int(11) UNSIGNED NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `body` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `payload` text COLLATE utf8mb4_unicode_ci,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 --
 -- Indexes for dumped tables
 --
@@ -210,6 +245,21 @@ ALTER TABLE `user_locations`
   ADD UNIQUE KEY `unique_email` (`email`);
 
 --
+-- Indexes for table `notification_devices`
+--
+ALTER TABLE `notification_devices`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `idx_notification_device_token` (`device_token`),
+  ADD KEY `idx_notification_email` (`email`);
+
+--
+-- Indexes for table `notification_log`
+--
+ALTER TABLE `notification_log`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `idx_notification_log_email` (`email`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -236,6 +286,18 @@ ALTER TABLE `pins`
 --
 ALTER TABLE `users`
   MODIFY `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+
+--
+-- AUTO_INCREMENT for table `notification_devices`
+--
+ALTER TABLE `notification_devices`
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
+
+--
+-- AUTO_INCREMENT for table `notification_log`
+--
+ALTER TABLE `notification_log`
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
 
 --
 -- Constraints for dumped tables


### PR DESCRIPTION
## Summary
- add an iOS push notification manager, AppDelegate integration, and API client hooks so the app can register for remote notifications and refresh the inbox after receiving replies
- introduce a reusable PHP NotificationService, REST endpoint for device tokens, and wire message creation to trigger reply push notifications
- create an admin notifications console, extend the dashboard navigation, and document new notification-related tables in the schema

## Testing
- php -l "Server (API and admin)/services/NotificationService.php"
- php -l "Server (API and admin)/api/notification_tokens.php"
- php -l "Server (API and admin)/admin/notifications.php"
- php -l "Server (API and admin)/api/messages.php"
- php -l "Server (API and admin)/admin/dashboard.php"

------
https://chatgpt.com/codex/tasks/task_e_68cf0b0543e4832284ba497b33e55a5b