### PR TITLE
Allow login with any email address

### DIFF
--- a/LSE Now/ViewModels/AuthViewModel.swift
+++ b/LSE Now/ViewModels/AuthViewModel.swift
@@ -29,6 +29,10 @@ final class AuthViewModel: ObservableObject {
     private let tokenStorage: TokenStorage
     private let pushManager: PushNotificationManager
     private var resendTimer: Timer?
+    private static let emailPredicate = NSPredicate(
+        format: "SELF MATCHES %@",
+        "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+    )
 
     init(
         apiService: APIService = .shared,
@@ -71,12 +75,12 @@ final class AuthViewModel: ObservableObject {
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         guard !trimmedEmail.isEmpty else {
-            errorMessage = "Please enter your LSE email address."
+            errorMessage = "Please enter your email address."
             return
         }
 
-        guard trimmedEmail.hasSuffix("@lse.ac.uk") else {
-            errorMessage = "Only @lse.ac.uk email addresses are supported."
+        guard isValidEmail(trimmedEmail) else {
+            errorMessage = "Please enter a valid email address."
             return
         }
 
@@ -168,5 +172,9 @@ final class AuthViewModel: ObservableObject {
         resendTimer?.invalidate()
         resendTimer = nil
         resendSecondsRemaining = 0
+    }
+
+    private func isValidEmail(_ email: String) -> Bool {
+        Self.emailPredicate.evaluate(with: email)
     }
 }

--- a/LSE Now/Views/LoginFlowView.swift
+++ b/LSE Now/Views/LoginFlowView.swift
@@ -15,7 +15,7 @@ struct LoginFlowView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Welcome to BeavR")
                         .font(.title.bold())
-                    Text("Sign in with your LSE email to continue.")
+                    Text("Sign in with your email to continue.")
                         .foregroundColor(.secondary)
                 }
 
@@ -42,7 +42,7 @@ struct LoginFlowView: View {
 
                 Spacer()
 
-                Text("Only @lse.ac.uk email addresses are eligible at this time.")
+                Text("We'll send you a one-time code to finish signing in.")
                     .font(.footnote)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.leading)
@@ -61,10 +61,10 @@ struct LoginFlowView: View {
 
     private var emailEntry: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("LSE Email")
+            Text("Email")
                 .font(.headline)
 
-            TextField("name@lse.ac.uk", text: $viewModel.email)
+            TextField("name@example.com", text: $viewModel.email)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .keyboardType(.emailAddress)

--- a/LSE Now/Views/NewEventView.swift
+++ b/LSE Now/Views/NewEventView.swift
@@ -197,7 +197,7 @@ struct MyEventsView: View {
                 .font(.headline)
                 .foregroundColor(.primary)
 
-            Text("Your submissions will appear here once you're signed in with your LSE email.")
+            Text("Your submissions will appear here once you're signed in with your email.")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Request a new verification code. Parameters:
 
 | Field | Description |
 | --- | --- |
-| `email` | LSE email address (`@lse.ac.uk`). |
+| `email` | Email address to send the login code to. |
 
 Successful response:
 
@@ -31,7 +31,7 @@ Successful response:
 Example error response (`400 Bad Request`):
 
 ```json
-{ "error": "Invalid email domain." }
+{ "error": "Invalid email address." }
 ```
 
 The endpoint generates a 6-digit code, stores it along with a 5-minute expiry window, and sends the email from `noreply@beavr.net`.
@@ -59,7 +59,7 @@ This endpoint manages event submissions and retrieval:
 
 * `POST api/events.php`
   * Requires an `Authorization: Bearer <token>` header with a valid login token.
-  * Accepts a JSON payload with the event details plus a `creator` field (the LSE email of the submitter). The server always persists the authenticated email in the `creator` column so the event can be tied back to the user.
+  * Accepts a JSON payload with the event details plus a `creator` field (the email of the submitter). The server always persists the authenticated email in the `creator` column so the event can be tied back to the user.
   * Stores the event as `pending` and returns the new event id.
 * `GET api/events.php`
   * Returns all live events for the public feed.
@@ -79,7 +79,7 @@ The schema creates a `users` table with the fields required for the flow plus a 
 
 The SwiftUI app now checks for a stored login token on launch. If a token exists, the user is taken directly to the main experience. Otherwise a two-step login flow is presented:
 
-1. Enter an `@lse.ac.uk` email address to trigger `request_code.php`.
+1. Enter an email address to trigger `request_code.php`.
 2. Enter the six-digit code from the email to call `verify_code.php`.
 
 After successful verification the login token is saved locally (via `UserDefaults`), so future launches bypass the login flow until the app is reinstalled.

--- a/Server (API and admin)/admin/notifications.php
+++ b/Server (API and admin)/admin/notifications.php
@@ -158,7 +158,7 @@ function shortToken(string $token): string
             <textarea id="body" name="body" required><?= htmlspecialchars($body, ENT_QUOTES, 'UTF-8') ?></textarea>
 
             <label for="target_email">Target email</label>
-            <input type="text" id="target_email" name="target_email" value="<?= htmlspecialchars($targetEmail, ENT_QUOTES, 'UTF-8') ?>" placeholder="student@lse.ac.uk">
+            <input type="text" id="target_email" name="target_email" value="<?= htmlspecialchars($targetEmail, ENT_QUOTES, 'UTF-8') ?>" placeholder="student@example.com">
 
             <label for="extra">Optional JSON payload</label>
             <textarea id="extra" name="extra" placeholder='{"url":"https://..."}'><?= htmlspecialchars($extraJson, ENT_QUOTES, 'UTF-8') ?></textarea>

--- a/Server (API and admin)/api/request_code.php
+++ b/Server (API and admin)/api/request_code.php
@@ -15,9 +15,9 @@ if ($email === '') {
     exit;
 }
 
-if (!preg_match('/^[A-Za-z0-9._%+-]+@lse\.ac\.uk$/', $email)) {
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
     http_response_code(400);
-    echo json_encode(['error' => 'Invalid email domain.']);
+    echo json_encode(['error' => 'Invalid email address.']);
     exit;
 }
 
@@ -58,9 +58,9 @@ try {
 }
 
 if (!$isDemoAccount) {
-    $subject = 'Your LSE Events Login Code';
+    $subject = 'Your BeavR Login Code';
     $message = sprintf("Your login code is: %s (valid for 5 minutes).", $code);
-    $headers = "From: LSE Events <noreply@beavr.net>\r\n";
+    $headers = "From: BeavR <noreply@beavr.net>\r\n";
 
     $mailSent = mail($email, $subject, $message, $headers);
 


### PR DESCRIPTION
## Summary
- accept any valid email address during login and refresh the SwiftUI copy accordingly
- update the backend request_code endpoint to allow any valid email and tweak related documentation
- adjust admin tooling placeholders to avoid implying an lse.ac.uk-only workflow

## Testing
- php -l 'Server (API and admin)/api/request_code.php'
- php -l 'Server (API and admin)/admin/notifications.php'

------
https://chatgpt.com/codex/tasks/task_e_68cf2a69b58083228363b08ee2dfe2cb