### PR TITLE
Prune expired whiteboard pins before returning API responses

### DIFF
--- a/Server (API and admin)/api/pins.php
+++ b/Server (API and admin)/api/pins.php
@@ -1,8 +1,27 @@
 <?php
 require_once __DIR__ . "/../config.php"; // adjust path if needed
 
+const PIN_LIFETIME_SECONDS = 8 * 60 * 60;
+
+function pruneExpiredPins(PDO $pdo, int $lifetimeSeconds): void
+{
+    $lifetimeSeconds = max(0, $lifetimeSeconds);
+    if ($lifetimeSeconds === 0) {
+        return;
+    }
+
+    $cleanupQuery = sprintf(
+        "DELETE FROM pins WHERE created_at <= (NOW() - INTERVAL %d SECOND)",
+        $lifetimeSeconds
+    );
+
+    $pdo->exec($cleanupQuery);
+}
+
 $pdo = getPDO();
 header("Content-Type: application/json");
+
+pruneExpiredPins($pdo, PIN_LIFETIME_SECONDS);
 
 $method = $_SERVER["REQUEST_METHOD"];
 


### PR DESCRIPTION
## Summary
- prune expired pins on every pins API request so expired rows are removed from storage
- centralize the pin lifetime as a constant used by the cleanup helper

## Testing
- php -l 'Server (API and admin)/api/pins.php'


------
https://chatgpt.com/codex/tasks/task_e_68d01db2a90c8322849cc2b19d132311