### PR TITLE
Update pin reply notification copy

### DIFF
--- a/Server (API and admin)/api/messages.php
+++ b/Server (API and admin)/api/messages.php
@@ -210,7 +210,8 @@ function createMessage(PDO $pdo): void
                 $senderEmail,
                 (int) $row['pin_id'],
                 $formattedMessage['message'] ?? '',
-                $messageId
+                $messageId,
+                $formattedMessage['author'] ?? null
             );
         } catch (Throwable $notifyException) {
             logMessage('⚠️ Notification send failed → ' . $notifyException->getMessage());


### PR DESCRIPTION
## Summary
- change whiteboard reply push notifications to use a pinned message style title/body and include the sender name
- prefer a provided reply author when available and keep a preview of the reply text in the payload
- pass the reply author through the API when delivering push notifications

## Testing
- php -l 'Server (API and admin)/services/NotificationService.php'
- php -l 'Server (API and admin)/api/messages.php'

------
https://chatgpt.com/codex/tasks/task_e_68d01f27c8788322a407d61118c741be