### PR TITLE
Dim map pin view for in-progress events

### DIFF
--- a/LSE Now/Views/MapView.swift
+++ b/LSE Now/Views/MapView.swift
@@ -78,7 +78,8 @@ struct MapView: View {
                                     if usePinStyle {
                                         EventPinView(
                                             post: post,
-                                            isSameDay: isSameDay
+                                            isSameDay: isSameDay,
+                                            hasStarted: hasStarted
                                         )
                                         .transition(.scale.combined(with: .opacity))
                                     } else {
@@ -297,6 +298,7 @@ private struct PostAnnotationView: View {
 private struct EventPinView: View {
     let post: Post
     let isSameDay: Bool
+    let hasStarted: Bool
 
     private var pinColor: Color {
         isSameDay ? Color("LSERed") : .white
@@ -328,6 +330,7 @@ private struct EventPinView: View {
                     .stroke(strokeColor, lineWidth: 2)
             )
             .shadow(color: shadowColor, radius: 4, y: 2)
+            .opacity(hasStarted ? 0.6 : 1.0)
     }
 
     private var pinGradient: LinearGradient {


### PR DESCRIPTION
## Summary
- dim the pin-style map annotation when an event has already started to match the square annotation opacity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0252eb6e4832292b015808a16fe09