### PR TITLE
Make live indicator pulse more visible

### DIFF
--- a/LSE Now/Views/FeedView.swift
+++ b/LSE Now/Views/FeedView.swift
@@ -216,14 +216,15 @@ struct FeedView: View {
             HStack(spacing: 6) {
                 ZStack {
                     Circle()
-                        .fill(Color.red.opacity(0.2))
-                        .frame(width: 14, height: 14)
-                        .scaleEffect(blink ? 1.2 : 0.8)
-                        .opacity(blink ? 0.2 : 0.8)
+                        .fill(Color("LSERed").opacity(0.45))
+                        .frame(width: 16, height: 16)
+                        .scaleEffect(blink ? 1.45 : 0.95)
+                        .opacity(blink ? 0.35 : 0.85)
 
                     Circle()
-                        .fill(Color.red)
+                        .fill(Color("LSERed"))
                         .frame(width: 8, height: 8)
+                        .shadow(color: Color("LSERed").opacity(0.5), radius: 2)
                 }
                 .animation(.easeInOut(duration: 1).repeatForever(autoreverses: true), value: blink)
 


### PR DESCRIPTION
## Summary
- increase the pulsing halo size and opacity for the live status indicator
- use the LSERed asset color for both halo and core dot and add a subtle glow to highlight it

## Testing
- not run (requires Xcode/iOS simulator which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0297a58508322b1aab38bf0d46e1b