### PR TITLE
Reposition map legend and refine like interactions

### DIFF
--- a/LSE Now/Views/FeedView.swift
+++ b/LSE Now/Views/FeedView.swift
@@ -119,36 +119,36 @@ struct FeedView: View {
 
                         ForEach(filteredPosts) { post in
                             NavigationLink(destination: PostDetailView(post: post, viewModel: vm)) {
-                                ZStack(alignment: .topTrailing) {
-                                    // Background card
-                                    VStack(alignment: .leading, spacing: 6) {
-                                        Text("\(categoryEmoji(for: post.category)) \(post.title)")
-                                            .font(.headline)
-                                            .foregroundColor(.primary)
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("\(categoryEmoji(for: post.category)) \(post.title)")
+                                        .font(.headline)
+                                        .foregroundColor(.primary)
 
-                                        if let org = post.organization, !org.isEmpty {
-                                            Text("by \(org)")
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-
-                                        dateOrLiveView(for: post)
+                                    if let org = post.organization, !org.isEmpty {
+                                        Text("by \(org)")
                                             .font(.subheadline)
+                                            .foregroundColor(.secondary)
                                     }
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding()
-                                    .background(Color(.systemBackground))
-                                    .cornerRadius(12)
-                                    .shadow(radius: 1)
 
-                                    EventLikeButton(
-                                        isLiked: post.likedByMe,
-                                        likeCount: post.likesCount,
-                                        isLoading: vm.isUpdatingLike(for: post.id),
-                                        action: { handleLike(for: post) }
-                                    )
-                                    .padding(12)
+                                    dateOrLiveView(for: post)
+                                        .font(.subheadline)
+
+                                    HStack {
+                                        Spacer()
+                                        EventLikeButton(
+                                            isLiked: post.likedByMe,
+                                            likeCount: post.likesCount,
+                                            isLoading: vm.isUpdatingLike(for: post.id),
+                                            action: { handleLike(for: post) }
+                                        )
+                                        .padding(.top, 8)
+                                    }
                                 }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding()
+                                .background(Color(.systemBackground))
+                                .cornerRadius(12)
+                                .shadow(radius: 1)
                             }
                             .buttonStyle(PlainButtonStyle())
                         }

--- a/LSE Now/Views/MapView.swift
+++ b/LSE Now/Views/MapView.swift
@@ -102,6 +102,12 @@ struct MapView: View {
                         .annotationTitles(.hidden)
                     }
                 }
+                .mapControls {
+                    MapCompass()
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    mapLegend
+                }
                 .ignoresSafeArea()
                 .onAppear {
                     vm.fetchPosts()
@@ -221,6 +227,18 @@ struct MapView: View {
     private func stopTimer() {
         timer?.invalidate()
         timer = nil
+    }
+
+    @ViewBuilder
+    private var mapLegend: some View {
+        if #available(iOS 17.0, *) {
+            MapScaleView()
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.thinMaterial, in: Capsule())
+                .padding(.trailing, 12)
+                .padding(.bottom, 20)
+        }
     }
 
     private func timeLabel(for start: Date, endTime: Date?) -> String {


### PR DESCRIPTION
## Summary
- reposition the map scale legend to the bottom-right and prevent it from covering annotation times
- refresh feed cards to place the like button at the bottom-right with animated counts and no material background
- optimistically update likes in the detail view while enlarging the heart icon and keeping the UI in sync

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d08ce860e08322a7ef6d7b0b3d2ff0