### PR TITLE
Adjust event like button animation and layout

### DIFF
--- a/LSE Now/Views/FeedView.swift
+++ b/LSE Now/Views/FeedView.swift
@@ -130,19 +130,23 @@ struct FeedView: View {
                                             .foregroundColor(.secondary)
                                     }
 
-                                    dateOrLiveView(for: post)
-                                        .font(.subheadline)
+                                    HStack(alignment: .firstTextBaseline) {
+                                        dateOrLiveView(for: post)
+                                            .font(.subheadline)
 
-                                    HStack {
-                                        Spacer()
+                                        Spacer(minLength: 12)
+
                                         EventLikeButton(
                                             isLiked: post.likedByMe,
                                             likeCount: post.likesCount,
                                             isLoading: vm.isUpdatingLike(for: post.id),
                                             action: { handleLike(for: post) }
                                         )
-                                        .padding(.top, 8)
+                                        .alignmentGuide(.firstTextBaseline) { context in
+                                            context[VerticalAlignment.center]
+                                        }
                                     }
+                                    .padding(.top, 8)
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding()


### PR DESCRIPTION
## Summary
- replace the like button pop animation with a fade-only effect that keeps the icon size consistent
- reset the feed card layout so the like button shares a baseline with the event time information

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d090def9b48322bfb57855fd3a8282