### PR TITLE
Handle missing status column when authenticating

### DIFF
--- a/Server (API and admin)/api/event_likes.php
+++ b/Server (API and admin)/api/event_likes.php
@@ -100,7 +100,7 @@ function requireAuth(PDO $pdo): array
         respondWithError(401, 'Missing bearer token.');
     }
 
-    $user = findUserByToken($pdo, $token);
+    $user = fetchUserByToken($pdo, $token);
     if ($user === null) {
         respondWithError(401, 'Invalid or expired token.');
     }
@@ -110,23 +110,6 @@ function requireAuth(PDO $pdo): array
     }
 
     return $user;
-}
-
-function findUserByToken(PDO $pdo, string $token): ?array
-{
-    $stmt = $pdo->prepare('SELECT id, email, status FROM users WHERE login_token = :token LIMIT 1');
-    $stmt->execute([':token' => $token]);
-    $user = $stmt->fetch(PDO::FETCH_ASSOC);
-
-    if (!$user) {
-        return null;
-    }
-
-    return [
-        'id' => (int)$user['id'],
-        'email' => strtolower((string)$user['email']),
-        'status' => normalizeUserStatus($user['status'] ?? null),
-    ];
 }
 
 function extractBearerToken(): ?string

--- a/Server (API and admin)/api/events.php
+++ b/Server (API and admin)/api/events.php
@@ -273,7 +273,7 @@ function requireAuth(PDO $pdo): array
         respondWithError(401, 'Missing bearer token.');
     }
 
-    $user = findUserByToken($pdo, $token);
+    $user = fetchUserByToken($pdo, $token);
 
     if ($user === null) {
         respondWithError(401, 'Invalid or expired token.');
@@ -293,30 +293,13 @@ function tryAuth(PDO $pdo): ?array
         return null;
     }
 
-    $user = findUserByToken($pdo, $token);
+    $user = fetchUserByToken($pdo, $token);
 
     if ($user !== null && userIsBanned($user)) {
         respondWithError(403, ACCOUNT_SUSPENDED_MESSAGE);
     }
 
     return $user;
-}
-
-function findUserByToken(PDO $pdo, string $token): ?array
-{
-    $stmt = $pdo->prepare('SELECT id, email, status FROM users WHERE login_token = :token LIMIT 1');
-    $stmt->execute([':token' => $token]);
-    $user = $stmt->fetch(PDO::FETCH_ASSOC);
-
-    if (!$user) {
-        return null;
-    }
-
-    return [
-        'id' => (int)$user['id'],
-        'email' => strtolower((string)$user['email']),
-        'status' => normalizeUserStatus($user['status'] ?? null),
-    ];
 }
 
 function extractBearerToken(): ?string

--- a/Server (API and admin)/api/whiteboard_helpers.php
+++ b/Server (API and admin)/api/whiteboard_helpers.php
@@ -66,11 +66,9 @@ function extractBearerToken(): ?string
 function findUserByToken(PDO $pdo, string $token): ?array
 {
     helperLog("findUserByToken searching for token='{$token}'");
-    $stmt = $pdo->prepare('SELECT id, email, status FROM users WHERE login_token = :token LIMIT 1');
-    $stmt->execute([':token' => $token]);
-    $user = $stmt->fetch();
+    $user = fetchUserByToken($pdo, $token);
 
-    if (!$user) {
+    if ($user === null) {
         helperLog("findUserByToken failed → no user for token");
         return null;
     }


### PR DESCRIPTION
## Summary
- avoid selecting the `status` field when the users table lacks the column and default to a regular status
- update API endpoints to reuse the centralized token lookup helper so authentication works without the column

## Testing
- php -l 'Server (API and admin)/api/auth_helpers.php'
- php -l 'Server (API and admin)/api/events.php'
- php -l 'Server (API and admin)/api/event_likes.php'
- php -l 'Server (API and admin)/api/deals.php'
- php -l 'Server (API and admin)/api/whiteboard_helpers.php'

------
https://chatgpt.com/codex/tasks/task_e_68d09c2f7e40832286097a84fbd3b6d2