### PR TITLE
Load database credentials from .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.env
+/Server (API and admin)/.env

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This repository now includes a lightweight PHP backend that powers the email + o
 ## Backend setup
 
 1. Create the tables using the schema in [`database/schema.sql`](database/schema.sql). This now provisions both the `users` table for authentication and an `events` table that stores every submitted event together with its creator email and publication status.
-2. Provide the database connection credentials through the following environment variables before serving the PHP scripts (the shared `config.php` will refuse to bootstrap without them and will return HTTP 500 instead of leaking stack traces):
+2. Provide the database connection credentials through the following environment variables before serving the PHP scripts (the shared `config.php` will refuse to bootstrap without them and will return HTTP 500 instead of leaking stack traces). You can set them in your shell, configure them in your web server, or create a `.env` file (either at the repository root or inside `Server (API and admin)/`) with the same key/value pairs:
    - `DB_HOST`
    - `DB_NAME`
    - `DB_USER`
    - `DB_PASS`
-   You can export them directly in your shell prior to calling `php -S`, place them in your web server's environment configuration (for example Apache's `SetEnv` or nginx's `fastcgi_param`), or load them via a deployment-specific secrets manager.
+   For local development you can copy [`Server (API and admin)/.env.example`](Server%20(API%20and%20admin)/.env.example) to `.env` and customise the values.
 3. Deploy the contents of the [`api/`](api) directory to your PHP-capable web server. Both scripts expect `config.php` one level above them so they can share the PDO connection.
 
 ### Available endpoints

--- a/Server (API and admin)/.env.example
+++ b/Server (API and admin)/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to `.env` and fill in the credentials for your MySQL instance.
+# The configuration loader in config.php reads both Server (API and admin)/.env
+# and the repository root ./.env file.
+DB_HOST=127.0.0.1
+DB_NAME=beavr
+DB_USER=beavr
+DB_PASS=secret

--- a/Server (API and admin)/config.php
+++ b/Server (API and admin)/config.php
@@ -1,6 +1,91 @@
 <?php
 // Central DB config — supports both global $pdo and getPDO()
 
+function envVarDefined(string $key): bool
+{
+    if (getenv($key) !== false) {
+        return true;
+    }
+
+    if (isset($_ENV) && array_key_exists($key, $_ENV)) {
+        return true;
+    }
+
+    if (isset($_SERVER) && array_key_exists($key, $_SERVER)) {
+        return true;
+    }
+
+    return false;
+}
+
+function loadEnvFile(string $path): void
+{
+    if (!is_file($path) || !is_readable($path)) {
+        return;
+    }
+
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if ($lines === false) {
+        return;
+    }
+
+    foreach ($lines as $line) {
+        if (!is_string($line)) {
+            continue;
+        }
+
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#' || $line[0] === ';') {
+            continue;
+        }
+
+        if (stripos($line, 'export ') === 0) {
+            $line = trim(substr($line, 7));
+        }
+
+        if ($line === '' || strpos($line, '=') === false) {
+            continue;
+        }
+
+        [$name, $value] = explode('=', $line, 2);
+        $name = trim($name);
+        $value = trim($value);
+
+        if ($name === '' || envVarDefined($name)) {
+            continue;
+        }
+
+        if ($value !== '' && ($value[0] === '"' || $value[0] === "'")) {
+            $quote = $value[0];
+            if (substr($value, -1) === $quote) {
+                $value = substr($value, 1, -1);
+                if ($quote === '"') {
+                    $value = stripcslashes($value);
+                }
+            }
+        }
+
+        putenv(sprintf('%s=%s', $name, $value));
+        if (!isset($_ENV)) {
+            $_ENV = [];
+        }
+        if (!isset($_SERVER)) {
+            $_SERVER = [];
+        }
+        $_ENV[$name] = $value;
+        $_SERVER[$name] = $value;
+    }
+}
+
+$dotenvPaths = [
+    __DIR__ . '/.env',
+    dirname(__DIR__) . '/.env',
+];
+
+foreach ($dotenvPaths as $dotenvPath) {
+    loadEnvFile($dotenvPath);
+}
+
 function readEnv(string $key): ?string {
     $candidates = [
         getenv($key),


### PR DESCRIPTION
## Summary
- allow the shared PHP config to read credentials from optional .env files
- add a committed .env.example for the API directory and ignore developer-specific secrets
- document the new configuration option in the backend setup instructions

## Testing
- php -l 'Server (API and admin)/config.php'

------
https://chatgpt.com/codex/tasks/task_e_68d161ab38a48322a316e7cea948074f