### PR TITLE
Add unread indicator to messages toolbar icon

### DIFF
--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -11,6 +11,7 @@ struct WhiteboardView: View {
     @State private var selectedPin: WhiteboardPin?
     @State private var showingInbox = false
     @State private var showingHowItWorks = false
+    @State private var hasUnreadMessages = false
 
     private let rows = WhiteboardGridConfiguration.rows
     private let columns = WhiteboardGridConfiguration.columns
@@ -59,15 +60,35 @@ struct WhiteboardView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         showingInbox = true
+                        hasUnreadMessages = false
                     } label: {
                         Image(systemName: "envelope")
                             .padding(.top, 2)
+                            .overlay(alignment: .topTrailing) {
+                                if hasUnreadMessages {
+                                    Circle()
+                                        .fill(Color.red)
+                                        .frame(width: 10, height: 10)
+                                        .offset(x: 6, y: -6)
+                                }
+                            }
                     }
-                    .accessibilityLabel("Open messages inbox")
+                    .accessibilityLabel(
+                        hasUnreadMessages
+                            ? "Open messages inbox, new messages available"
+                            : "Open messages inbox"
+                    )
                 }
             }
             .task {
                 await viewModel.loadPins()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: PushNotificationManager.messageReplyReceivedNotification)) { _ in
+                if showingInbox {
+                    hasUnreadMessages = false
+                } else {
+                    hasUnreadMessages = true
+                }
             }
             .alert(
                 "Unable to Load Pins",


### PR DESCRIPTION
## Summary
- track whether new messages have arrived via push notifications in the whiteboard view
- show a small red badge on the messages toolbar icon and clear it when the inbox opens
- adjust the accessibility label to announce when unread messages are waiting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d173238c38832291261ceec902d725