### PR TITLE
Add pin deletion flow and dynamic pin outline

### DIFF
--- a/LSE Now/Networking/APIService.swift
+++ b/LSE Now/Networking/APIService.swift
@@ -267,6 +267,20 @@ final class APIService {
         return try decoder.decode(WhiteboardPin.self, from: data)
     }
 
+    func deletePin(id: Int, token: String) async throws {
+        let endpoint = baseURL.appendingPathComponent("pins.php")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        setAuthorizationHeader(on: &request, token: token)
+
+        let encoder = JSONEncoder()
+        request.httpBody = try encoder.encode(DeletePinRequest(id: id))
+
+        _ = try await perform(request: request)
+    }
+
     // MARK: - Messages
     func sendPinReply(payload: PinReplyPayload, token: String) async throws -> WhiteboardMessage {
         let endpoint = baseURL.appendingPathComponent("messages.php")
@@ -521,6 +535,10 @@ struct CreatePinRequest: Encodable {
     let creatorEmail: String
     let gridRow: Int
     let gridCol: Int
+}
+
+private struct DeletePinRequest: Encodable {
+    let id: Int
 }
 
 struct PinReplyPayload: Encodable {

--- a/LSE Now/ViewModels/WhiteboardViewModel.swift
+++ b/LSE Now/ViewModels/WhiteboardViewModel.swift
@@ -155,6 +155,24 @@ final class WhiteboardViewModel: ObservableObject {
         print("➕ Added new pin at (\(newPin.gridRow),\(newPin.gridCol)). Total now=\(pins.count)")
     }
 
+    func deletePin(_ pin: WhiteboardPin, token: String) async throws {
+        print("🗑️ Deleting pin id=\(pin.id)")
+        do {
+            try await apiService.deletePin(id: pin.id, token: token)
+            pins.removeAll { $0.id == pin.id }
+
+            if pins.isEmpty {
+                expirationTimer?.invalidate()
+                expirationTimer = nil
+            }
+
+            print("✅ Deleted pin id=\(pin.id). Remaining pins=\(pins.count)")
+        } catch {
+            print("❌ Failed to delete pin id=\(pin.id): \(error.localizedDescription)")
+            throw error
+        }
+    }
+
     func sendReply(to pin: WhiteboardPin, message: String, author: String?, token: String) async throws {
         guard !isSendingReply else { return }
 

--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -99,13 +99,23 @@ struct WhiteboardView: View {
                 }
             }
             .sheet(item: $selectedPin) { pin in
+                let token = activeToken
+                let canReply = token != nil
+                let canDelete = canReply && pin.creatorEmail == normalizedLoggedInEmail
+
                 PinDetailSheet(
                     pin: pin,
-                    canReply: activeToken != nil,
+                    canReply: canReply,
                     onReply: {
                         selectedPin = nil
                         replyTarget = pin
-                    }
+                    },
+                    canDelete: canDelete,
+                    onDelete: canDelete ? {
+                        if let token {
+                            try await viewModel.deletePin(pin, token: token)
+                        }
+                    } : nil
                 )
             }
             .sheet(item: $replyTarget) { pin in
@@ -279,14 +289,39 @@ private struct WhiteboardPinCell: View {
         }
         .frame(maxWidth: .infinity)
         .aspectRatio(1, contentMode: .fit)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(isMine ? Color("LSERed") : Color(.separator), lineWidth: isMine ? 2 : 1)
-        )
+        .overlay(borderOverlay(referenceDate: referenceDate))
         .opacity(isSeen ? 0.7 : 1.0)
         .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel(referenceDate: referenceDate))
+    }
+
+    @ViewBuilder
+    private func borderOverlay(referenceDate: Date) -> some View {
+        let baseShape = RoundedRectangle(cornerRadius: 16, style: .continuous)
+
+        if isMine {
+            let progress = CGFloat(pin.remainingLifetimeFraction(referenceDate: referenceDate))
+
+            ZStack {
+                baseShape
+                    .stroke(Color(.separator), lineWidth: 1)
+
+                if progress > 0 {
+                    baseShape
+                        .trim(from: 0, to: progress)
+                        .stroke(
+                            Color("LSERed"),
+                            style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
+                        )
+                        .rotation(Angle(degrees: -90))
+                        .animation(.easeInOut(duration: 0.35), value: progress)
+                }
+            }
+        } else {
+            baseShape
+                .stroke(Color(.separator), lineWidth: 1)
+        }
     }
 
     private func accessibilityLabel(referenceDate: Date) -> String {
@@ -338,6 +373,12 @@ private struct PinDetailSheet: View {
     let pin: WhiteboardPin
     let canReply: Bool
     let onReply: () -> Void
+    let canDelete: Bool
+    let onDelete: (() async throws -> Void)?
+
+    @State private var isDeleting = false
+    @State private var deleteError: String?
+    @State private var showingDeleteConfirmation = false
 
     var body: some View {
         NavigationStack {
@@ -416,18 +457,76 @@ private struct PinDetailSheet: View {
                         .background(Color("LSERed"))
                         .cornerRadius(16)
                 }
-                .disabled(!canReply || isExpired)
-                .opacity((canReply && !isExpired) ? 1 : 0.5)
+                .disabled(!canReply || isExpired || isDeleting)
+                .opacity((canReply && !isExpired && !isDeleting) ? 1 : 0.5)
 
                 if !canReply {
                     Text("Log in to reply to pins.")
                         .font(.footnote)
                         .foregroundColor(.secondary)
                 }
+
+                if canDelete, let onDelete {
+                    Button(role: .destructive) {
+                        showingDeleteConfirmation = true
+                    } label: {
+                        if isDeleting {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .tint(Color("LSERed"))
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                        } else {
+                            Text("Delete Pin")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                        }
+                    }
+                    .disabled(isDeleting)
+                    .confirmationDialog(
+                        "Delete this pin?",
+                        isPresented: $showingDeleteConfirmation,
+                        titleVisibility: .visible
+                    ) {
+                        Button("Delete Pin", role: .destructive) {
+                            Task { await handleDelete(onDelete: onDelete) }
+                        }
+                        Button("Cancel", role: .cancel) { }
+                    }
+                }
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 24)
         }
+        .alert("Couldn't Delete Pin", isPresented: Binding(
+            get: { deleteError != nil },
+            set: { newValue in
+                if !newValue {
+                    deleteError = nil
+                }
+            }
+        )) {
+            Button("OK", role: .cancel) { deleteError = nil }
+        } message: {
+            Text(deleteError ?? "")
+        }
+    }
+
+    @MainActor
+    private func handleDelete(onDelete: @escaping () async throws -> Void) async {
+        guard !isDeleting else { return }
+        showingDeleteConfirmation = false
+        isDeleting = true
+
+        do {
+            try await onDelete()
+            dismiss()
+        } catch {
+            deleteError = error.localizedDescription
+        }
+
+        isDeleting = false
     }
 }
 


### PR DESCRIPTION
## Summary
- allow authenticated users to delete their own pins through the API service and backend endpoint
- expose a delete action from the pin detail sheet and update the pin grid border to show remaining lifetime progress

## Testing
- php -l 'Server (API and admin)/api/pins.php'

------
https://chatgpt.com/codex/tasks/task_e_68d1730a3a488322b4e089627aed956c