### PR TITLE
Fix SwiftUI warnings in WhiteboardView

### DIFF
--- a/LSE Now/Views/WhiteboardView.swift
+++ b/LSE Now/Views/WhiteboardView.swift
@@ -160,7 +160,7 @@ struct WhiteboardView: View {
                 }
             }
         }
-        .onChange(of: viewModel.pins) { newPins in
+        .onChange(of: viewModel.pins) { _, newPins in
             seenPinsStore.sync(with: newPins)
         }
     }
@@ -227,6 +227,7 @@ struct WhiteboardView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.pins)
     }
 
+    @MainActor
     private func refreshPins() async {
         print("🔄 [Refresh] Starting refreshPins()")
         print("🔄 [Refresh] Current thread: \(Thread.isMainThread ? "Main" : "Background")")
@@ -335,8 +336,8 @@ private struct WhiteboardPinCell: View {
                             Color("LSERed"),
                             style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
                         )
-                        .rotation(Angle(degrees: -90))
-                        .animation(.easeInOut(duration: 0.35), value: progress)
+                        .rotationEffect(.degrees(-90))
+                        .animation(Animation.easeInOut(duration: 0.35), value: progress)
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- update the Pinboard view's change handler to use the modern onChange overload
- mark refreshPins as a @MainActor function and modernize shape modifiers to resolve Swift 6 errors

## Testing
- not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d177dd9fd48322a445513fe9caea56