### PR TITLE
Adjust ModeIntroduction visibility for enum Mode

### DIFF
--- a/LSE Now/Views/NewEventView.swift
+++ b/LSE Now/Views/NewEventView.swift
@@ -111,7 +111,7 @@ struct HubRectButton: View {
 
 // MARK: - Placeholder Views
 struct MyEventsView: View {
-    private struct ModeIntroduction {
+    fileprivate struct ModeIntroduction {
         let icon: String
         let accent: Color
         let message: String


### PR DESCRIPTION
## Summary
- change the ModeIntroduction helper struct to fileprivate so Mode's computed properties can reference it without access level conflicts

## Testing
- not run (requires macOS build environment)


------
https://chatgpt.com/codex/tasks/task_e_68d18ca5bb9c8322b3f0aca5e3f5fb0a