### PR TITLE
Rework guided introduction layout and navigation

### DIFF
--- a/LSE Now/Views/MainTabView.swift
+++ b/LSE Now/Views/MainTabView.swift
@@ -47,10 +47,10 @@ struct MainTabView: View {
         .accentColor(Color("LSERed"))
         .overlay {
             if showIntroduction {
-                GuidedIntroductionOverlay(isPresented: $showIntroduction) {
+                GuidedIntroductionOverlay(isPresented: $showIntroduction, selectedTab: $selection) {
                     hasSeenMainGuide = true
                 }
-                .transition(.opacity.combined(with: .scale))
+                .transition(.opacity)
                 .zIndex(2)
             }
         }


### PR DESCRIPTION
## Summary
- restyled the guided introduction with a bottom-aligned panel that contains the step content and next button plus a top-left skip control
- synced intro steps with tab navigation so advancing highlights Feed, Pinboard, Deals, then Share & Save before fading back to the Map when finished

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19ef29b388322b92a173d91cf8599